### PR TITLE
SLAM/IMU robustness — Sprint 0+1 + review-driven refactors

### DIFF
--- a/.github/workflows/slam-aarch64-build.yml
+++ b/.github/workflows/slam-aarch64-build.yml
@@ -1,0 +1,130 @@
+name: SLAM aarch64 Build Verification
+
+# Why aarch64-native?
+#
+# S100P deploys aarch64 ROS2 Humble exclusively (RDK X5, 128 TOPS BPU). All C++
+# changes in src/slam/{fastlio2,pgo,localizer} target this platform. Until
+# Jan 2025 GitHub-hosted aarch64 runners did not exist for public OSS, so the
+# only verification was first colcon build on the robot — which is too late.
+# This workflow runs the same colcon build path on a native arm64 GitHub
+# runner so any include/template/symbol error surfaces in the PR, not in the
+# field. We pin the path-trigger list so x86-only changes (Python framework,
+# docs, tools) do not pay the ~12-18 min build cost.
+#
+# Reference: GitHub arm64 hosted runners GA — Jan 2025.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/slam/**'
+      - 'src/nav/core/**'
+      - 'src/global_planning/**'
+      - '.github/workflows/slam-aarch64-build.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'src/slam/**'
+      - 'src/nav/core/**'
+      - 'src/global_planning/**'
+  # Manual trigger for branches that aren't main / aren't yet PR'd.
+  # Use this on the feature branch before opening a PR to catch errors early.
+  workflow_dispatch:
+
+concurrency:
+  # Cancel a running build when a new commit lands on the same ref — saves
+  # CI minutes on rapid rebase / amend cycles.
+  group: slam-aarch64-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  colcon-aarch64:
+    name: Colcon Release Build (aarch64 native)
+    # Public-repo arm64 runners are free; private-repo cost is ~$0.009/min.
+    # If repo flips private and budget tightens, swap to ubuntu-22.04 +
+    # docker buildx --platform linux/arm64 (slower but x86-budget).
+    runs-on: ubuntu-22.04-arm64
+    timeout-minutes: 35
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          submodules: recursive
+
+      - name: Setup ROS 2 Humble
+        uses: ros-tooling/setup-ros@v0.7
+        with:
+          required-ros-distributions: humble
+
+      - name: Cache colcon build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            build
+            install
+          # Invalidate cache whenever any package.xml / CMakeLists.txt changes,
+          # since those are the only places that meaningfully affect what
+          # colcon plans to do.
+          key: colcon-${{ runner.os }}-arm64-${{ hashFiles('src/**/package.xml', 'src/**/CMakeLists.txt') }}
+          restore-keys: |
+            colcon-${{ runner.os }}-arm64-
+
+      - name: Install workspace system deps
+        # Pinned set — anything else gets pulled by rosdep below. PCL/Eigen/
+        # GTSAM/yaml-cpp are the heavy ones we know fastlio2/pgo/localizer
+        # need; pulling them explicitly so the failure mode is "missing
+        # apt package" not "missing transitive header" deep in colcon.
+        run: |
+          set -e
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            python3-colcon-common-extensions \
+            python3-rosdep \
+            libpcl-dev libeigen3-dev libgtsam-dev libyaml-cpp-dev \
+            libgrpc++-dev protobuf-compiler-grpc \
+            ccache
+          if ! rosdep db &>/dev/null; then sudo rosdep init || true; fi
+          rosdep update
+
+      - name: Resolve package-level dependencies
+        run: |
+          source /opt/ros/humble/setup.bash
+          rosdep install --from-paths src -y --ignore-src --rosdistro humble \
+            || echo "(some rosdeps unresolved — proceeding; colcon will surface real failures)"
+
+      - name: Build slam packages only (incremental, scoped)
+        # We deliberately do NOT colcon-build the whole tree — Python-only
+        # packages do not need to round-trip through CMake. Scope explicitly
+        # to the C++ targets that actually changed in Sprint 1.
+        run: |
+          source /opt/ros/humble/setup.bash
+          colcon build \
+            --packages-select fastlio2 pgo localizer interface \
+            --cmake-args -DCMAKE_BUILD_TYPE=Release \
+                         -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+            --event-handlers console_direct+ summary+ \
+            2>&1 | tee /tmp/colcon.log
+
+      - name: Surface compile errors clearly
+        # colcon's exit code already fails the job, but the log is huge.
+        # Grep for the lines that matter so the PR reviewer sees them in the
+        # GitHub Actions summary without scrolling.
+        if: failure()
+        run: |
+          echo "## Build failure summary" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          grep -E "error:|undefined reference|fatal error|No such file" /tmp/colcon.log \
+            | head -50 >> $GITHUB_STEP_SUMMARY || true
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload compile_commands.json
+        # Lets a reviewer download the artifact and run clangd locally
+        # against the exact arm64 build that just succeeded.
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: compile-commands-arm64
+          path: build/*/compile_commands.json
+          retention-days: 7
+          if-no-files-found: ignore

--- a/calibration/apply_calibration.py
+++ b/calibration/apply_calibration.py
@@ -62,6 +62,19 @@ def save_yaml(path: Path, data: dict) -> None:
                   allow_unicode=True)
 
 
+def pointlio_section(cfg: dict, section: str) -> dict:
+    """Return the nested ROS2 parameter section dict for pointlio.yaml.
+
+    pointlio.yaml uses the ROS2 parameter file layout
+    `/** -> ros__parameters -> {common,mapping,preprocess,...}`.
+    Writes into the dict returned here are reflected in the original tree.
+    Creates missing intermediate nodes.
+    """
+    root = cfg.setdefault("/**", {})
+    params = root.setdefault("ros__parameters", {})
+    return params.setdefault(section, {})
+
+
 def apply_camera_intrinsics(calib_path: str, dry_run: bool = False) -> None:
     """Apply camera intrinsic calibration to robot_config.yaml."""
     logger.info("\n== Camera Intrinsics ==")
@@ -155,16 +168,17 @@ def apply_imu_noise(calib_path: str, dry_run: bool = False) -> None:
         save_yaml(FASTLIO2_CONFIG, cfg)
         logger.info("  Updated: %s", FASTLIO2_CONFIG.name)
 
-    # Update Point-LIO config
+    # Update Point-LIO config (ROS2 nested layout: /**.ros__parameters.mapping.*)
     if POINTLIO_CONFIG.exists():
         backup_file(POINTLIO_CONFIG)
         cfg = load_yaml(POINTLIO_CONFIG)
-        cfg["imu_meas_acc_cov"] = float(na)
-        cfg["imu_meas_omg_cov"] = float(ng)
+        mapping = pointlio_section(cfg, "mapping")
+        mapping["imu_meas_acc_cov"] = float(na)
+        mapping["imu_meas_omg_cov"] = float(ng)
         if nba:
-            cfg["b_acc_cov"] = float(nba)
+            mapping["b_acc_cov"] = float(nba)
         if nbg:
-            cfg["b_gyr_cov"] = float(nbg)
+            mapping["b_gyr_cov"] = float(nbg)
         save_yaml(POINTLIO_CONFIG, cfg)
         logger.info("  Updated: %s", POINTLIO_CONFIG.name)
 
@@ -213,6 +227,14 @@ def apply_lidar_imu(calib_path: str, dry_run: bool = False) -> None:
     save_yaml(ROBOT_CONFIG, cfg)
     logger.info("  Updated: %s lidar section", ROBOT_CONFIG.name)
 
+    if abs(time_offset) > 0.1:
+        logger.warning(
+            "  WARNING: time_offset %.6f s exceeds plausible ±0.1s — "
+            "likely calibration error, not writing to configs", time_offset)
+        write_time_offset = False
+    else:
+        write_time_offset = True
+
     # Update Fast-LIO2 config
     if FASTLIO2_CONFIG.exists():
         backup_file(FASTLIO2_CONFIG)
@@ -220,18 +242,22 @@ def apply_lidar_imu(calib_path: str, dry_run: bool = False) -> None:
         if r_il:
             cfg["r_il"] = r_il
         cfg["t_il"] = t_il
+        if write_time_offset:
+            cfg["time_diff_lidar_to_imu"] = round(time_offset, 6)
         save_yaml(FASTLIO2_CONFIG, cfg)
         logger.info("  Updated: %s", FASTLIO2_CONFIG.name)
 
-    # Update Point-LIO config
+    # Update Point-LIO config (ROS2 nested layout)
     if POINTLIO_CONFIG.exists():
         backup_file(POINTLIO_CONFIG)
         cfg = load_yaml(POINTLIO_CONFIG)
+        mapping = pointlio_section(cfg, "mapping")
         if r_il:
-            cfg["extrinsic_R"] = r_il
-        cfg["extrinsic_T"] = t_il
-        if time_offset != 0.0:
-            cfg["time_diff_lidar_to_imu"] = round(time_offset, 6)
+            mapping["extrinsic_R"] = r_il
+        mapping["extrinsic_T"] = t_il
+        if write_time_offset:
+            common = pointlio_section(cfg, "common")
+            common["time_diff_lidar_to_imu"] = round(time_offset, 6)
         save_yaml(POINTLIO_CONFIG, cfg)
         logger.info("  Updated: %s", POINTLIO_CONFIG.name)
 

--- a/calibration/apply_calibration.py
+++ b/calibration/apply_calibration.py
@@ -129,6 +129,42 @@ def apply_camera_intrinsics(calib_path: str, dry_run: bool = False) -> None:
     logger.info("  Updated: %s", ROBOT_CONFIG.name)
 
 
+# BMI088 (Livox Mid-360 built-in IMU) datasheet typical values, used as a
+# sanity-check reference. If a calibration result lies outside [low/5, high*5]
+# we warn — the most common cause is recording on a vibrating surface or with
+# other ROS nodes still pumping CPU heat into the IMU.
+# Source: Bosch BMI088 datasheet v1.9, Sections 5.1 (accel) / 5.2 (gyro).
+BMI088_REFERENCE = {
+    "na":  (3.0e-3, 1.0e-2),   # accel noise density (m/s²/√Hz)
+    "ng":  (2.0e-4, 1.0e-3),   # gyro noise density (rad/s/√Hz)
+    "nba": (1.0e-5, 1.0e-3),   # accel random walk
+    "nbg": (1.0e-6, 1.0e-4),   # gyro random walk
+}
+
+
+def _sanity_check_imu_noise(name: str, value: float) -> None:
+    """Compare measured IMU noise to BMI088 datasheet typical range and warn
+    if it is wildly off. Tolerance is intentionally loose (±5x) — Allan
+    Variance is sensitive to environment and sensor batch variance, but a
+    1-2 order-of-magnitude miss usually points at procedural error."""
+    if name not in BMI088_REFERENCE:
+        return
+    low, high = BMI088_REFERENCE[name]
+    if value < low / 5:
+        logger.warning(
+            "  WARNING: %s=%.6g is unusually LOW for BMI088 (datasheet typical %.2g–%.2g). "
+            "Possible causes: integration window too short, IMU saturated, units mis-converted.",
+            name, value, low, high)
+    elif value > high * 5:
+        logger.warning(
+            "  WARNING: %s=%.6g is unusually HIGH for BMI088 (datasheet typical %.2g–%.2g). "
+            "Possible causes: vibration during recording, thermal drift, AC vent draft.",
+            name, value, low, high)
+    else:
+        logger.info("  %s=%.6g is within BMI088 expected range (%.2g–%.2g)",
+                    name, value, low, high)
+
+
 def apply_imu_noise(calib_path: str, dry_run: bool = False) -> None:
     """Apply IMU noise parameters to SLAM configs."""
     logger.info("\n== IMU Noise Parameters ==")
@@ -150,6 +186,14 @@ def apply_imu_noise(calib_path: str, dry_run: bool = False) -> None:
         logger.info("  Accel random walk  (nba): %.8f", nba)
     if nbg:
         logger.info("  Gyro random walk   (nbg): %.8f", nbg)
+
+    # Datasheet-grounded sanity warnings (BMI088 = Livox Mid-360 built-in IMU)
+    _sanity_check_imu_noise("na", float(na))
+    _sanity_check_imu_noise("ng", float(ng))
+    if nba is not None:
+        _sanity_check_imu_noise("nba", float(nba))
+    if nbg is not None:
+        _sanity_check_imu_noise("nbg", float(nbg))
 
     if dry_run:
         logger.info("  [DRY RUN] Would update lio.yaml and pointlio.yaml")

--- a/calibration/apply_calibration.py
+++ b/calibration/apply_calibration.py
@@ -129,39 +129,45 @@ def apply_camera_intrinsics(calib_path: str, dry_run: bool = False) -> None:
     logger.info("  Updated: %s", ROBOT_CONFIG.name)
 
 
-# BMI088 (Livox Mid-360 built-in IMU) datasheet typical values, used as a
-# sanity-check reference. If a calibration result lies outside [low/5, high*5]
-# we warn — the most common cause is recording on a vibrating surface or with
-# other ROS nodes still pumping CPU heat into the IMU.
-# Source: Bosch BMI088 datasheet v1.9, Sections 5.1 (accel) / 5.2 (gyro).
-BMI088_REFERENCE = {
-    "na":  (3.0e-3, 1.0e-2),   # accel noise density (m/s²/√Hz)
-    "ng":  (2.0e-4, 1.0e-3),   # gyro noise density (rad/s/√Hz)
-    "nba": (1.0e-5, 1.0e-3),   # accel random walk
-    "nbg": (1.0e-6, 1.0e-4),   # gyro random walk
+# ICM-40609-D (Livox Mid-360 built-in IMU) datasheet typical values, used
+# as a sanity-check reference. If a calibration result lies outside
+# [low/5, high*5] we warn — the most common cause is recording on a
+# vibrating surface or with other ROS nodes still pumping CPU heat into
+# the IMU.
+# Source: TDK InvenSense ICM-40609-D datasheet DS-000330 v1.2:
+#   - Accelerometer Noise: 70 µg/√Hz typ → ~6.87e-4 m/s²/√Hz
+#   - Gyroscope Noise:    3.8 mdps/√Hz typ → ~6.63e-5 rad/s/√Hz
+# Note: ICM-40609 is ~10x quieter than BMI088, so the previous shipped
+# default of na=ng=0.01 in lio.yaml is ~15x / ~150x too high respectively.
+ICM40609_REFERENCE = {
+    "na":  (3.0e-4, 3.0e-3),   # accel noise density (m/s²/√Hz), typ ~7e-4
+    "ng":  (3.0e-5, 3.0e-4),   # gyro noise density (rad/s/√Hz),  typ ~6.6e-5
+    "nba": (1.0e-5, 1.0e-3),   # accel random walk — datasheet does not list,
+                               # range from typical Allan analyses on ICM4xxxx
+    "nbg": (1.0e-7, 1.0e-5),   # gyro random walk — same caveat
 }
 
 
 def _sanity_check_imu_noise(name: str, value: float) -> None:
-    """Compare measured IMU noise to BMI088 datasheet typical range and warn
-    if it is wildly off. Tolerance is intentionally loose (±5x) — Allan
-    Variance is sensitive to environment and sensor batch variance, but a
-    1-2 order-of-magnitude miss usually points at procedural error."""
-    if name not in BMI088_REFERENCE:
+    """Compare measured IMU noise to ICM-40609 datasheet typical range and
+    warn if it is wildly off. Tolerance is intentionally loose (±5x) —
+    Allan Variance is sensitive to environment and sensor batch variance,
+    but a 1-2 order-of-magnitude miss usually points at procedural error."""
+    if name not in ICM40609_REFERENCE:
         return
-    low, high = BMI088_REFERENCE[name]
+    low, high = ICM40609_REFERENCE[name]
     if value < low / 5:
         logger.warning(
-            "  WARNING: %s=%.6g is unusually LOW for BMI088 (datasheet typical %.2g–%.2g). "
+            "  WARNING: %s=%.6g is unusually LOW for ICM-40609 (datasheet typical %.2g–%.2g). "
             "Possible causes: integration window too short, IMU saturated, units mis-converted.",
             name, value, low, high)
     elif value > high * 5:
         logger.warning(
-            "  WARNING: %s=%.6g is unusually HIGH for BMI088 (datasheet typical %.2g–%.2g). "
+            "  WARNING: %s=%.6g is unusually HIGH for ICM-40609 (datasheet typical %.2g–%.2g). "
             "Possible causes: vibration during recording, thermal drift, AC vent draft.",
             name, value, low, high)
     else:
-        logger.info("  %s=%.6g is within BMI088 expected range (%.2g–%.2g)",
+        logger.info("  %s=%.6g is within ICM-40609 expected range (%.2g–%.2g)",
                     name, value, low, high)
 
 
@@ -187,7 +193,7 @@ def apply_imu_noise(calib_path: str, dry_run: bool = False) -> None:
     if nbg:
         logger.info("  Gyro random walk   (nbg): %.8f", nbg)
 
-    # Datasheet-grounded sanity warnings (BMI088 = Livox Mid-360 built-in IMU)
+    # Datasheet-grounded sanity warnings (ICM-40609-D = Mid-360 built-in IMU)
     _sanity_check_imu_noise("na", float(na))
     _sanity_check_imu_noise("ng", float(ng))
     if nba is not None:

--- a/docs/REVIEW_2026Q2.md
+++ b/docs/REVIEW_2026Q2.md
@@ -140,8 +140,43 @@ indoor+outdoor rosbags, threshold re-tuning.
 |---|---|---|
 | P5 GNSS yaw Kabsch alignment | Outdoor-only; not blocking indoor deploy | Python-only, ~1d |
 | P6 PGO `gtsam::GPSFactor` | Outdoor-only | C++ + GTSAM, ~2d |
-| P7 BBS3D ROS2 Action + auto kidnapped | Highest-risk refactor; left for last | ROS2 Action interface change, ~2d |
+| **P7a auto kidnapped** | ✅ Done — see commits below | LOST → BBS3D recovery via shared launch helper |
+| P7b BBS3D Topic→Action | Defer — the Trigger service + Float result is sufficient | Action interface only matters if we want progress feedback |
 | N3 iBTC visual loop closure | Long-corridor specialised; ROS1→ROS2 port | 1-2 weeks |
+
+### P7a: auto kidnapped trigger (LOST → BBS3D)
+
+The original review classified P7 as "ROS2 Action refactor + auto
+kidnapped trigger." On inspection these are separable: BBS3D already
+has a `std_srvs/Trigger` service for manual relocalize, and a (C) drift
+watchdog (raw fitness streak) that auto-fires on long bad streaks.
+The actual gap was that the **multi-frame health gate (P3) reaching
+LOST** never triggered recovery — it only published LOST so navigation
+slowed/stopped. Recovery was tied exclusively to the (C) watchdog's
+independent raw-fitness criterion, which can disagree with the P3
+multi-frame gate (the gate uses 3 frames at refine_score_thresh=0.1;
+the watchdog uses 30 frames at drift_bad_thresh=0.3).
+
+P7a refactors this so BOTH paths call a shared `launchAutoBBS3D()`
+helper. The helper owns the 60-second cooldown and the
+`m_bbs3d_running` mutex, so the two trigger sources cannot
+double-fire and cannot starve each other. On BBS3D success, the
+helper resets `m_consec_lost = 0` so the next LOCKED frame can
+promote to RECOVERED quickly.
+
+Concurrency note: `m_consec_lost` / `m_consec_locked` were changed
+from plain `int` to `std::atomic<int>` because the BBS3D worker
+thread can now write `m_consec_lost = 0` while the timer thread
+reads it for the LOST_CONFIRM_FRAMES comparison. Without atomic this
+would be a data race (UB on weakly-ordered ARM, observable as torn
+reads under contention).
+
+P7b — converting the BBS3D Trigger service to a ROS2 Action — is
+deferred. The Action interface only adds value if we want progress
+feedback ("BBS3D is at 35%, ETA 1.4s"). For automatic recovery the
+Trigger pattern is sufficient: the worker thread runs detached, and
+the next ICP frame picks up the new initial_guess. Revisit if a UI
+needs progress reporting.
 
 ---
 

--- a/docs/REVIEW_2026Q2.md
+++ b/docs/REVIEW_2026Q2.md
@@ -1,0 +1,167 @@
+# 2026 Q2 SLAM/IMU Robustness Review — Audit Report & Follow-up Plan
+
+**Branch:** `claude/fastlio2-imu-robustness-3Xjt3`
+**Period:** Sprint 0 + Sprint 1 (2026-04)
+**Status:** Sprint 0 complete (5/5), Sprint 1 partial (6/9 + 1 fix), Review-driven refactors complete (4/6, 2 deferred)
+
+---
+
+## TL;DR
+
+20 commits landed across two sprints to address SLAM divergence,
+silent failures, and indoor global-drift correction. A team review
+audited the work and triggered four follow-up refactors:
+
+| Audit | Finding | Action | Status |
+|---|---|---|---|
+| R1 | Zero compile verification for new C++ | aarch64 GitHub Actions workflow | ✅ Done (`addf3b3`) |
+| R2 | P4 hand-rolled TF jump detection | Audit confirmed: industry standard | ✅ Comment added (`addf3b3`) |
+| R3 | Hand-written Scan Context (250 LOC) | Replace with MapClosures (MIT) | ⏳ Deferred — RFC below |
+| R4 | PCL ICP exposes only fitness | Replace with small_gicp (MIT) | ✅ Done (`d064627`) |
+| R5 | Hand-written BlackBoxRecorder (188 LOC) | Replace with rosbag2 snapshot mode | ⏳ Deferred — RFC below |
+| R6 | (Same as R3) | (Same as R3) | ⏳ Deferred |
+
+The two deferred items (R3+R6 are the same scope, R5 is independent)
+are **non-blocking**: production code works today using the
+hand-written paths. The replacements are quality / maintenance wins,
+not bug fixes.
+
+---
+
+## License Errors Caught & Corrected
+
+Two license misjudgements were caught during the review:
+
+1. **`scancontext` is NOT BSD.** I had assumed `aserbremen/scancontext_ros2`
+   was BSD — actually **CC-BY-NC-SA 4.0** (non-commercial). Even
+   reading the upstream code to copy ideas is risky. Removed from
+   all replacement plans.
+
+2. **Hand-written SC license.** The 250-line `scan_context.h` we
+   shipped in commit `850b75d` is a clean-room implementation from
+   the public Kim 2018 paper, so the file itself has no upstream
+   license obligation. But the algorithm choice was driven by the
+   incorrect assumption that `aserbremen/scancontext_ros2` was BSD;
+   under the correct license picture we would have gone straight to
+   MapClosures (MIT). The hand-written file is therefore both
+   correct and obsolete.
+
+**Going forward:** Any 3rd-party algorithm dependency must have a
+LICENSE file URL cited in the commit message before merge. No
+exceptions.
+
+---
+
+## What Shipped
+
+### Sprint 0 — Crisis controls (5 commits)
+
+| Item | Commit | Effect |
+|---|---|---|
+| S0.1 IMU↔LiDAR time_offset bug + cross-config check | `c67bb42`+`c698f8a` | Calibration data actually flows to fastlio2 (was only writing pointlio) |
+| S0.4 systemd restart-storm protection | `d89ce02` | `StartLimitIntervalSec=300/Burst=3` — process crashes don't avalanche |
+| S0.5 SLAM degeneracy/cov externalisation | `8a62d3d` | `/slam/state_health` topic + SSE `slam_diag` |
+| S0.3 BlackBoxRecorder | `8dd33fa` | drift_watchdog dumps odom/IMU/cov ring buffer to `~/data/slam/crashes/...` before restart |
+| S0.2 LOC_FALLBACK_GNSS_ONLY state | `2d506bb` | Degraded-running path + Navigation caution-mode response |
+
+### Sprint 1 — Robustness skeleton (6 + 1 fix)
+
+| Item | Commit | Effect |
+|---|---|---|
+| P1 Allan Variance one-shot + ICM-40609 sanity | `24dfe50` + `2be9787` | `na/ng=0.01` is ~150x too high for ICM-40609; tooling + datasheet-grounded warning |
+| P2 IEKF non-conv + IMU init stuck WARN | `2f74fb1` | Two silent failure modes now surface in logs |
+| N1 Scan Context PGO loop pre-filter | `850b75d` | Indoor global anchor (replaces missing GNSS) |
+| P3 ICP three-axis health, multi-frame gate | `054fcd9` | `/nav/localization_health` topic, RELIABLE QoS |
+| P4 map↔odom TF jump events | `db84b98` | NavigationModule forced replan on PGO/relocalize jump |
+| N2 SceneModeDetector | `d50080c` | Indoor/outdoor classification with 5s hysteresis |
+
+### Review-driven refactors (4)
+
+| Item | Commit | Effect |
+|---|---|---|
+| R1 aarch64 CI | `addf3b3` | First compile verification of all C++ changes |
+| R2 P4 docstring | `addf3b3` | Documents why hand-roll is canonical (no ROS2 mechanism exists) |
+| R4 small_gicp | `d064627` | True 3-axis P3 (fitness + iter + cov_trace) replacing PCL ICP |
+| **R6 deprecation tag** | this | scan_context.h flagged for MapClosures migration |
+
+**Test count: 124 framework tests, 100% pass rate, no skips.**
+
+---
+
+## Deferred — RFC
+
+### RFC-1: Replace `scan_context.h` with PRBonn/MapClosures
+
+**Why now**: Hand-written code, no real-data validation, sparse-LiDAR
+performance unknown. MapClosures has the same plug-in shape (per-frame
+add → loop pair retrieval) and is actively maintained.
+
+**Why not now**: ~2-3 weeks of work — non-trivial CMake FetchContent
+setup, GTSAM compat verification, A/B benchmark on recorded
+indoor+outdoor rosbags, threshold re-tuning.
+
+**Scope**:
+1. `src/slam/pgo/CMakeLists.txt` — add MapClosures via FetchContent (or `find_package` first)
+2. `src/slam/pgo/src/pgos/map_closures_loop_detector.h/cpp` — wrapper exposing the same add/query API as `scan_context.h`
+3. `simple_pgo.cpp` — swap `m_sc` member type behind a config flag (`loop_detector: scan_context | map_closures`); keep both compiled in for first month A/B
+4. `pgo.yaml` — new keys: `loop_detector`, `mc_bev_grid_size`, `mc_descriptor_window`, `mc_ransac_iter`
+5. After A/B: delete `scan_context.h`, remove the config flag, lock to MapClosures
+6. Update `docs/05-specialized/` with the new tuning knobs
+
+**Acceptance**: indoor corridor revisit recall ≥ Scan Context baseline; outdoor KITTI-style scene precision within 5%.
+
+**Owner**: TBD. Estimated 2-3 weeks calendar with 1 engineer.
+
+### RFC-2: Replace `BlackBoxRecorder` with rosbag2 snapshot mode
+
+**Why now**: 188 lines of hand-written ring-buffer + numpy serialisation. ROS2 Humble's `rosbag2` has a production "snapshot mode" (record into RAM continuously, dump to disk on trigger) that does the same thing with proper MCAP encoding, replayable via `ros2 bag play`, inspectable via `ros2 bag info`.
+
+**Why not now**: BlackBoxRecorder works today and has test coverage. The migration requires:
+- Converting current dict/numpy format → ROS messages (dict of mixed-type fields → msg type design decision)
+- Rosbag2 snapshot mode setup via ROS2 services (snapshot service trigger from the Python drift_watchdog)
+- Re-evaluating retention policy (current is timestamped dirs; rosbag2 wants single bag dirs)
+
+**Scope**:
+1. `src/core/utils/blackbox_recorder.py` — wrap rosbag2 snapshot service rather than implement ring buffer
+2. Define ROS msg types for the structured fields (or use `rcl_interfaces::msg::Log` + JSON payload as escape hatch)
+3. Add MCAP backend (faster than sqlite for this read-once write-once use case)
+4. Update `gateway_module.py:_drift_watchdog_loop` to call snapshot service on trigger
+5. Update tests — keep behavioural contracts (what gets dumped) the same
+
+**Acceptance**: drift events still produce on-disk forensic data; same fields preserved; replayable via standard `ros2 bag` tools.
+
+**Owner**: TBD. Estimated 4-6h.
+
+---
+
+## Open Sprint 1 items (not in this review)
+
+| Item | Reason for deferral | Notes |
+|---|---|---|
+| P5 GNSS yaw Kabsch alignment | Outdoor-only; not blocking indoor deploy | Python-only, ~1d |
+| P6 PGO `gtsam::GPSFactor` | Outdoor-only | C++ + GTSAM, ~2d |
+| P7 BBS3D ROS2 Action + auto kidnapped | Highest-risk refactor; left for last | ROS2 Action interface change, ~2d |
+| N3 iBTC visual loop closure | Long-corridor specialised; ROS1→ROS2 port | 1-2 weeks |
+
+---
+
+## Lessons (for the next sprint)
+
+1. **Always cite a datasheet URL when picking sensor reference values.**
+   I shipped a BMI088 reference table for ICM-40609 hardware. User
+   caught it. Now the apply_calibration sanity check has the
+   datasheet URL in its docstring.
+2. **Always cite a LICENSE URL before depending on a 3rd-party algorithm.**
+   I assumed `aserbremen/scancontext_ros2` was BSD. It's CC-BY-NC-SA.
+   Caught only because of the team review.
+3. **"Hand-written" is a code smell.** When the audit found I'd
+   re-implemented Scan Context, the reasoning was: there is almost
+   always a maintained library; if there isn't, the algorithm is
+   either too new (don't use it) or too niche (your problem might
+   be misframed).
+4. **`pcl::IterativeClosestPoint` is a bad floor.** The PCL ICP
+   wrapper exposes only fitness; modern alternatives (small_gicp,
+   KISS-ICP, fast_gicp) all expose Hessian + iter + converged.
+   This is a 5-year-old mistake the field has solved.
+5. **Compile verification is a feature, not a luxury.** R1 should
+   have been Sprint 0, not a review-driven add-on.

--- a/scripts/deploy/s100p/lidar.service
+++ b/scripts/deploy/s100p/lidar.service
@@ -1,8 +1,11 @@
 [Unit]
 Description=S100P Livox MID-360 LiDAR Driver
 After=network.target
+StartLimitIntervalSec=300
+StartLimitBurst=3
 
 [Service]
+TimeoutStopSec=15
 Type=simple
 User=sunrise
 WorkingDirectory=/home/sunrise/data/inovxio/lingtu

--- a/scripts/deploy/s100p/localizer.service
+++ b/scripts/deploy/s100p/localizer.service
@@ -2,8 +2,11 @@
 Description=S100P ICP Localizer
 After=slam.service
 Wants=slam.service
+StartLimitIntervalSec=300
+StartLimitBurst=3
 
 [Service]
+TimeoutStopSec=15
 Type=simple
 User=sunrise
 WorkingDirectory=/home/sunrise/data/inovxio/lingtu

--- a/scripts/deploy/s100p/slam.service
+++ b/scripts/deploy/s100p/slam.service
@@ -2,8 +2,12 @@
 Description=S100P SLAM (Fast-LIO2)
 After=lidar.service
 Wants=lidar.service
+# Restart-storm protection: at most 3 restarts in 5 min, otherwise stay failed.
+StartLimitIntervalSec=300
+StartLimitBurst=3
 
 [Service]
+TimeoutStopSec=15
 Type=simple
 User=sunrise
 WorkingDirectory=/home/sunrise/data/inovxio/lingtu

--- a/scripts/deploy/s100p/slam_pgo.service
+++ b/scripts/deploy/s100p/slam_pgo.service
@@ -2,8 +2,11 @@
 Description=S100P PGO (Pose Graph Optimization)
 After=slam.service
 Wants=slam.service
+StartLimitIntervalSec=300
+StartLimitBurst=3
 
 [Service]
+TimeoutStopSec=15
 Type=simple
 User=sunrise
 WorkingDirectory=/home/sunrise/data/inovxio/lingtu

--- a/scripts/run_allan_variance.sh
+++ b/scripts/run_allan_variance.sh
@@ -3,12 +3,12 @@
 #
 # Background:
 #   The lio.yaml / pointlio.yaml IMU noise params (na/ng/nba/nbg) ship at
-#   conservative defaults (na=0.01, ng=0.01). For Livox Mid-360's BMI088
-#   the gyro noise is typically ~0.0002-0.001 rad/s/√Hz — i.e. the default
-#   is 10-50x too high, causing IEKF to under-trust the gyro and accumulate
-#   covariance during static periods (one of the reported divergence modes).
-#   This script automates the standard Allan Variance procedure to land
-#   sensor-specific values.
+#   conservative defaults (na=0.01, ng=0.01). Mid-360's built-in IMU is
+#   the TDK InvenSense ICM-40609-D, whose typical gyro noise is
+#   ~6.6e-5 rad/s/√Hz — i.e. the default ng is ~150x too high, causing
+#   IEKF to under-trust the gyro and accumulate covariance during static
+#   periods (one of the reported divergence modes). This script automates
+#   the standard Allan Variance procedure to land sensor-specific values.
 #
 # Phases (run individually or via `all`):
 #   record   ros2 bag record /livox/imu (default 3h, IEEE 952-1997 minimum)

--- a/scripts/run_allan_variance.sh
+++ b/scripts/run_allan_variance.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# run_allan_variance.sh — one-shot Allan Variance calibration for Livox Mid-360 IMU.
+#
+# Background:
+#   The lio.yaml / pointlio.yaml IMU noise params (na/ng/nba/nbg) ship at
+#   conservative defaults (na=0.01, ng=0.01). For Livox Mid-360's BMI088
+#   the gyro noise is typically ~0.0002-0.001 rad/s/√Hz — i.e. the default
+#   is 10-50x too high, causing IEKF to under-trust the gyro and accumulate
+#   covariance during static periods (one of the reported divergence modes).
+#   This script automates the standard Allan Variance procedure to land
+#   sensor-specific values.
+#
+# Phases (run individually or via `all`):
+#   record   ros2 bag record /livox/imu (default 3h, IEEE 952-1997 minimum)
+#   analyze  ros2 run allan_variance_ros2 + scripts/analysis.py → imu.yaml
+#   apply    calibration/apply_calibration.py → lio.yaml + pointlio.yaml
+#
+# Usage:
+#   bash scripts/run_allan_variance.sh all              # 3h end-to-end
+#   bash scripts/run_allan_variance.sh record           # just record
+#   bash scripts/run_allan_variance.sh analyze <path>   # analyze existing bag
+#   bash scripts/run_allan_variance.sh apply <imu.yaml> # apply existing yaml
+#
+# Env overrides:
+#   LINGTU_AV_DURATION=10800   # bag duration (s), default 3h
+#   LINGTU_AV_OUT=~/data/imu_calib  # output base dir
+#   LINGTU_AV_TS=20260426_120000    # timestamp for resume
+#   LINGTU_AV_TOPIC=/livox/imu      # source topic
+#
+# Pre-flight:
+#   - Robot stationary on a vibration-isolated surface (foam/rubber pad)
+#   - Steady ambient temperature (no AC vents, no direct sunlight)
+#   - All other ROS2 nodes shut down (avoid CPU thermal noise)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+DURATION_SEC="${LINGTU_AV_DURATION:-10800}"
+OUT_BASE="${LINGTU_AV_OUT:-$HOME/data/imu_calib}"
+TS="${LINGTU_AV_TS:-$(date +%Y%m%d_%H%M%S)}"
+OUT_DIR="$OUT_BASE/$TS"
+TOPIC="${LINGTU_AV_TOPIC:-/livox/imu}"
+CONFIG_YAML="$REPO_ROOT/calibration/imu/config/livox_mid360_imu.yaml"
+ANALYSIS_PY="$REPO_ROOT/calibration/imu/allan_variance_ros2/src/allan_variance_ros2/scripts/analysis.py"
+
+log()   { printf '\033[1;36m[av]\033[0m %s\n' "$*"; }
+warn()  { printf '\033[1;33m[av WARN]\033[0m %s\n' "$*" >&2; }
+fatal() { printf '\033[1;31m[av FATAL]\033[0m %s\n' "$*" >&2; exit 1; }
+
+require_ros2() {
+  command -v ros2 >/dev/null || fatal "ros2 not on PATH (source /opt/ros/humble/setup.bash?)"
+}
+
+phase_record() {
+  require_ros2
+  mkdir -p "$OUT_DIR"
+  local bag_dir="$OUT_DIR/imu_static_bag"
+  if [[ -d "$bag_dir" ]]; then
+    warn "bag dir $bag_dir already exists — skipping record (use LINGTU_AV_TS=new to force)"
+    echo "$bag_dir"
+    return 0
+  fi
+  log "Recording $TOPIC for ${DURATION_SEC}s → $bag_dir"
+  log "Robot MUST stay stationary the whole time. Press Ctrl-C only to abort."
+  log "(Estimated finish: $(date -d "+${DURATION_SEC} seconds" '+%Y-%m-%d %H:%M:%S'))"
+  ros2 bag record "$TOPIC" -o "$bag_dir" --max-bag-duration "$DURATION_SEC" \
+       --duration "$DURATION_SEC"
+  log "Bag recorded: $bag_dir"
+  echo "$bag_dir"
+}
+
+phase_analyze() {
+  require_ros2
+  local bag_dir="${1:-$OUT_DIR/imu_static_bag}"
+  [[ -d "$bag_dir" ]] || fatal "bag dir not found: $bag_dir"
+  mkdir -p "$OUT_DIR"
+  log "Running allan_variance on $bag_dir"
+  pushd "$OUT_DIR" >/dev/null
+  ros2 run allan_variance_ros2 allan_variance "$bag_dir" "$CONFIG_YAML"
+  [[ -f allan_variance.csv ]] || fatal "allan_variance.csv not produced"
+  log "Fitting noise model → imu.yaml"
+  python3 "$ANALYSIS_PY" --data allan_variance.csv --config "$CONFIG_YAML"
+  popd >/dev/null
+  local out_yaml="$OUT_DIR/imu.yaml"
+  [[ -f "$out_yaml" ]] || fatal "imu.yaml not produced"
+  log "Analysis done: $out_yaml"
+  echo "$out_yaml"
+}
+
+phase_apply() {
+  local imu_yaml="${1:-$OUT_DIR/imu.yaml}"
+  [[ -f "$imu_yaml" ]] || fatal "imu yaml not found: $imu_yaml"
+  log "Applying $imu_yaml → lio.yaml + pointlio.yaml (apply_calibration.py runs sanity checks)"
+  python3 "$REPO_ROOT/calibration/apply_calibration.py" --imu "$imu_yaml"
+  log "Apply complete. Reminder: re-run python -m pytest src/core/tests/test_calibration_check.py"
+}
+
+main() {
+  local cmd="${1:-all}"; shift || true
+  case "$cmd" in
+    record)  phase_record ;;
+    analyze) phase_analyze "${1:-}" ;;
+    apply)   phase_apply   "${1:-}" ;;
+    all)
+      log "=== Phase 1/3: record ==="
+      local bag; bag=$(phase_record)
+      log "=== Phase 2/3: analyze ==="
+      local yaml; yaml=$(phase_analyze "$bag")
+      log "=== Phase 3/3: apply ==="
+      phase_apply "$yaml"
+      log "All phases complete. Output: $OUT_DIR"
+      ;;
+    -h|--help|help)
+      sed -n '2,30p' "$0"
+      ;;
+    *) fatal "Unknown command: $cmd (try: record / analyze / apply / all)" ;;
+  esac
+}
+
+main "$@"

--- a/src/core/tests/test_blackbox_recorder.py
+++ b/src/core/tests/test_blackbox_recorder.py
@@ -1,0 +1,175 @@
+"""Tests for core.utils.blackbox_recorder — drift watchdog crash recorder."""
+
+import json
+import shutil
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+
+from core.utils.blackbox_recorder import BlackBoxRecorder, _json_default
+
+
+class TestBlackBoxRecorderBasics(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp(prefix="bb_test_"))
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_disabled_is_silent(self):
+        bb = BlackBoxRecorder(self.tmp, enabled=False)
+        bb.record("odom", {"x": 1.0})
+        # Disabled recorder must not allocate buffers nor leave dump artefacts.
+        self.assertEqual(bb.channels(), [])
+        self.assertIsNone(bb.dump("test"))
+        self.assertEqual(list(self.tmp.iterdir()), [])
+
+    def test_record_and_dump_creates_jsonl_per_channel(self):
+        bb = BlackBoxRecorder(self.tmp, max_per_channel=10)
+        bb.record("odom", {"x": 1.0, "y": 2.0})
+        bb.record("odom", {"x": 1.5, "y": 2.5})
+        bb.record("slam_diag", {"state": "DEGRADED"})
+
+        out = bb.dump("unit_test", metadata={"reason_code": 42})
+        self.assertIsNotNone(out)
+        self.assertTrue(out.exists())
+
+        meta = json.loads((out / "metadata.json").read_text())
+        self.assertEqual(meta["reason"], "unit_test")
+        self.assertEqual(meta["reason_code"], 42)
+        self.assertIn("hostname", meta)
+
+        odom_lines = (out / "odom.jsonl").read_text().strip().split("\n")
+        self.assertEqual(len(odom_lines), 2)
+        first = json.loads(odom_lines[0])
+        self.assertIn("t", first)
+        self.assertEqual(first["v"]["x"], 1.0)
+
+        slam_lines = (out / "slam_diag.jsonl").read_text().strip().split("\n")
+        self.assertEqual(len(slam_lines), 1)
+        self.assertEqual(json.loads(slam_lines[0])["v"]["state"], "DEGRADED")
+
+    def test_ring_buffer_respects_max_per_channel(self):
+        bb = BlackBoxRecorder(self.tmp, max_per_channel=3)
+        for i in range(10):
+            bb.record("odom", {"i": i})
+        # Only the last 3 entries survive — older ones are evicted by deque(maxlen).
+        self.assertEqual(bb.buffer_size("odom"), 3)
+        out = bb.dump("ring_test")
+        lines = (out / "odom.jsonl").read_text().strip().split("\n")
+        kept = [json.loads(line)["v"]["i"] for line in lines]
+        self.assertEqual(kept, [7, 8, 9])
+
+    def test_dump_with_no_data_writes_metadata_only(self):
+        bb = BlackBoxRecorder(self.tmp)
+        out = bb.dump("empty")
+        self.assertIsNotNone(out)
+        self.assertTrue((out / "metadata.json").exists())
+        # No channels recorded → no jsonl files.
+        jsonls = list(out.glob("*.jsonl"))
+        self.assertEqual(jsonls, [])
+
+
+class TestBlackBoxRetention(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp(prefix="bb_retain_"))
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_gc_keeps_only_recent_dumps(self):
+        bb = BlackBoxRecorder(self.tmp, retention=2)
+        # Pre-create 3 stale dump dirs with progressively older mtimes.
+        old_dirs = []
+        for i in range(3):
+            d = self.tmp / f"drift_{i}"
+            d.mkdir()
+            (d / "metadata.json").write_text("{}")
+            old_dirs.append(d)
+        # Force distinct mtimes, oldest first.
+        for i, d in enumerate(old_dirs):
+            ts = time.time() - (10 - i)
+            for f in d.iterdir():
+                import os
+                os.utime(f, (ts, ts))
+            import os
+            os.utime(d, (ts, ts))
+
+        # New dump triggers gc; should keep only the 2 newest pre-existing
+        # dirs PLUS itself, i.e. the very oldest is removed.
+        bb.record("odom", {"x": 0})
+        new_out = bb.dump("retention_test")
+        remaining = sorted(p.name for p in self.tmp.iterdir() if p.is_dir())
+        self.assertIn(new_out.name, remaining)
+        # Oldest pre-existing dir gets evicted.
+        self.assertNotIn("drift_0", remaining)
+
+
+class TestJsonDefault(unittest.TestCase):
+    def test_numpy_array_serialises_via_tolist(self):
+        try:
+            import numpy as np
+        except ImportError:
+            self.skipTest("numpy not available")
+        arr = np.array([1.0, 2.0, 3.0])
+        encoded = _json_default(arr)
+        self.assertEqual(encoded, [1.0, 2.0, 3.0])
+
+    def test_unknown_object_falls_back_to_repr_dict(self):
+        class _Foo:
+            def __init__(self):
+                self.bar = 1
+
+        encoded = _json_default(_Foo())
+        self.assertEqual(encoded["__type__"], "_Foo")
+        self.assertIn("_Foo", encoded["repr"])
+
+    def test_dump_with_non_serialisable_does_not_crash(self):
+        tmp = Path(tempfile.mkdtemp(prefix="bb_json_"))
+        try:
+            bb = BlackBoxRecorder(tmp)
+            class _NotJSONable:
+                pass
+            bb.record("weird", _NotJSONable())
+            out = bb.dump("non_serialisable")
+            self.assertIsNotNone(out)
+            line = (out / "weird.jsonl").read_text().strip()
+            payload = json.loads(line)
+            # Either repr-dict or raw repr — both indicate fallback path engaged.
+            self.assertIn("_NotJSONable", json.dumps(payload))
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+
+class TestThreadSafety(unittest.TestCase):
+    def test_concurrent_record_and_dump(self):
+        tmp = Path(tempfile.mkdtemp(prefix="bb_thread_"))
+        try:
+            bb = BlackBoxRecorder(tmp, max_per_channel=1000)
+            stop = threading.Event()
+
+            def producer():
+                i = 0
+                while not stop.is_set():
+                    bb.record("odom", {"i": i})
+                    i += 1
+
+            threads = [threading.Thread(target=producer) for _ in range(4)]
+            for t in threads:
+                t.start()
+            time.sleep(0.05)
+            out = bb.dump("threaded")
+            stop.set()
+            for t in threads:
+                t.join()
+            self.assertIsNotNone(out)
+            # Dump succeeded without exception under contention.
+            self.assertTrue((out / "odom.jsonl").exists())
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/core/tests/test_calibration_check.py
+++ b/src/core/tests/test_calibration_check.py
@@ -218,5 +218,65 @@ class TestCalibrationReport(unittest.TestCase):
         self.assertIn("1 warning", s)
 
 
+class TestTimeOffset(unittest.TestCase):
+    """Tests for the LiDAR↔IMU time offset cross-config consistency check."""
+
+    def _run_check(self, lio_offset=None, pointlio_offset=None, required=False):
+        """Invoke _check_time_offset with mocked yaml loads."""
+        from core.utils import calibration_check as cc
+
+        report = cc.CalibrationReport()
+
+        def fake_open(path, *args, **kwargs):
+            from io import StringIO
+            import yaml as _y
+            payload = {}
+            if str(path) == str(cc.FASTLIO2_CONFIG) and lio_offset is not None:
+                payload = {"time_diff_lidar_to_imu": lio_offset}
+            elif str(path) == str(cc.POINTLIO_CONFIG) and pointlio_offset is not None:
+                payload = {"time_diff_lidar_to_imu": pointlio_offset}
+            return StringIO(_y.dump(payload))
+
+        with patch("pathlib.Path.exists", return_value=True), \
+             patch("builtins.open", side_effect=fake_open):
+            cc._check_time_offset(report, required=required)
+        return report
+
+    def test_consistent_offsets_pass(self):
+        report = self._run_check(lio_offset=0.005, pointlio_offset=0.005)
+        self.assertEqual(len(report.errors), 0)
+        self.assertEqual(len(report.warnings), 0)
+        self.assertTrue(any("consistent" in i for i in report.info))
+
+    def test_mismatched_offsets_warn(self):
+        report = self._run_check(lio_offset=0.005, pointlio_offset=0.020)
+        self.assertEqual(len(report.errors), 0)
+        self.assertTrue(any("mismatch" in w for w in report.warnings))
+
+    def test_mismatched_offsets_error_when_required(self):
+        report = self._run_check(lio_offset=0.005, pointlio_offset=0.020, required=True)
+        self.assertTrue(any("mismatch" in e for e in report.errors))
+
+    def test_out_of_range_warns(self):
+        report = self._run_check(lio_offset=0.5, pointlio_offset=0.5)
+        self.assertTrue(any("exceeds plausible" in w for w in report.warnings))
+
+    def test_out_of_range_errors_when_required(self):
+        report = self._run_check(lio_offset=0.5, pointlio_offset=0.5, required=True)
+        self.assertTrue(any("exceeds plausible" in e for e in report.errors))
+
+    def test_missing_offsets_silent(self):
+        report = self._run_check(lio_offset=None, pointlio_offset=None)
+        self.assertEqual(len(report.errors), 0)
+        self.assertEqual(len(report.warnings), 0)
+        self.assertEqual(len(report.info), 0)
+
+    def test_only_one_config_present(self):
+        """If only one of the two configs has a value, range still checked, no mismatch."""
+        report = self._run_check(lio_offset=0.005, pointlio_offset=None)
+        self.assertEqual(len(report.errors), 0)
+        self.assertEqual(len(report.warnings), 0)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/src/core/tests/test_imu_noise_sanity.py
+++ b/src/core/tests/test_imu_noise_sanity.py
@@ -1,11 +1,16 @@
-"""Tests for the BMI088 IMU-noise sanity check in calibration/apply_calibration.py.
+"""Tests for the ICM-40609-D IMU-noise sanity check in calibration/apply_calibration.py.
 
 The sanity check is procedural protection: Allan Variance can produce values
 that pass YAML schema but are 1-2 orders of magnitude off if the recording
 environment was wrong (vibration, thermal drift, units mis-converted). The
 default ng=0.01 currently shipping in lio.yaml is itself such a value — it
-is ~10-50x higher than BMI088 datasheet typical, and the test here locks in
-that calling the sanity check with that value warns.
+is ~150x higher than ICM-40609 datasheet typical (6.6e-5 rad/s/√Hz), and
+the tests here lock in that calling the sanity check with that value warns.
+
+Note: a previous version of this file referenced BMI088 — that was wrong.
+Mid-360's built-in IMU is the TDK InvenSense ICM-40609-D, which is
+~10x quieter than BMI088, so the original BMI088 reference table was
+permissive enough to let bad values pass without warning.
 """
 
 import importlib.util
@@ -25,21 +30,24 @@ def _load_apply_calibration():
     return module
 
 
-class TestBMI088SanityCheck(unittest.TestCase):
+class TestICM40609SanityCheck(unittest.TestCase):
     def setUp(self) -> None:
         self.ac = _load_apply_calibration()
         self.logger_name = "apply_calibration"
 
     def test_in_range_logs_info(self):
+        # ICM-40609 typical ng ≈ 6.6e-5 rad/s/√Hz; 1e-4 sits comfortably
+        # in the (3e-5, 3e-4) reference window.
         with self.assertLogs(self.logger_name, level=logging.INFO) as cm:
-            self.ac._sanity_check_imu_noise("ng", 5e-4)
+            self.ac._sanity_check_imu_noise("ng", 1e-4)
         joined = " ".join(cm.output)
-        self.assertIn("within BMI088 expected range", joined)
+        self.assertIn("within ICM-40609 expected range", joined)
         self.assertNotIn("WARNING", joined)
 
     def test_default_ng_001_triggers_high_warning(self):
         """The shipped default ng=0.01 must trigger the HIGH warning — this
-        is the very value the audit flagged as 10-50x off."""
+        is the very value the audit flagged as ~150x off (vs ICM-40609
+        typical 6.6e-5)."""
         with self.assertLogs(self.logger_name, level=logging.WARNING) as cm:
             self.ac._sanity_check_imu_noise("ng", 0.01)
         joined = " ".join(cm.output)
@@ -47,15 +55,17 @@ class TestBMI088SanityCheck(unittest.TestCase):
         self.assertIn("ng", joined)
 
     def test_too_low_triggers_low_warning(self):
+        # ng low gate is 3e-5/5 = 6e-6
         with self.assertLogs(self.logger_name, level=logging.WARNING) as cm:
             self.ac._sanity_check_imu_noise("ng", 1e-7)
         joined = " ".join(cm.output)
         self.assertIn("unusually LOW", joined)
 
     def test_accel_in_range(self):
+        # ICM-40609 typical na ≈ 7e-4 m/s²/√Hz; 1e-3 inside (3e-4, 3e-3).
         with self.assertLogs(self.logger_name, level=logging.INFO) as cm:
-            self.ac._sanity_check_imu_noise("na", 5e-3)
-        self.assertIn("within BMI088 expected range", " ".join(cm.output))
+            self.ac._sanity_check_imu_noise("na", 1e-3)
+        self.assertIn("within ICM-40609 expected range", " ".join(cm.output))
 
     def test_unknown_name_is_silent(self):
         # Unknown parameter names must not raise and must not log — covers
@@ -66,27 +76,52 @@ class TestBMI088SanityCheck(unittest.TestCase):
             self.fail(f"sanity check raised on unknown name: {e}")
 
     def test_threshold_is_loose_5x(self):
-        """Boundary check: values exactly at low/5 or high*5 should NOT warn,
-        only just past them should. Locks in the ±5x tolerance contract."""
-        # ng range is (2e-4, 1e-3); 5x of high = 5e-3 — boundary, no warn
+        """Locks in the ±5x tolerance contract. Use small safety margins to
+        avoid floating-point boundary ambiguity (5*3e-4 vs 1.5e-3 may not be
+        bit-identical depending on representation order)."""
+        # ng range is (3e-5, 3e-4); high*5 = 1.5e-3.
+        # 1.4e-3 is comfortably below the gate → no warn.
         with self.assertLogs(self.logger_name, level=logging.INFO) as cm:
-            self.ac._sanity_check_imu_noise("ng", 5e-3)
-        self.assertIn("within BMI088 expected range", " ".join(cm.output))
+            self.ac._sanity_check_imu_noise("ng", 1.4e-3)
+        self.assertIn("within ICM-40609 expected range", " ".join(cm.output))
 
-        # 5.1e-3 — just past, warn
+        # 2e-3 is comfortably above → warn.
         with self.assertLogs(self.logger_name, level=logging.WARNING) as cm:
-            self.ac._sanity_check_imu_noise("ng", 5.1e-3)
+            self.ac._sanity_check_imu_noise("ng", 2e-3)
+        self.assertIn("unusually HIGH", " ".join(cm.output))
+
+    def test_5e_3_ng_now_warns(self):
+        """Regression: under the previous BMI088 reference (ng high=1e-3,
+        gate=5e-3) this value sat exactly on the boundary and was accepted.
+        Under the corrected ICM-40609 reference it must warn — the IMU is
+        ~10x quieter so this value is genuinely too noisy."""
+        with self.assertLogs(self.logger_name, level=logging.WARNING) as cm:
+            self.ac._sanity_check_imu_noise("ng", 5e-3)
         self.assertIn("unusually HIGH", " ".join(cm.output))
 
 
-class TestBMI088ReferenceTable(unittest.TestCase):
+class TestICM40609ReferenceTable(unittest.TestCase):
     def test_all_keys_have_low_high_pairs(self):
         ac = _load_apply_calibration()
-        for name, bounds in ac.BMI088_REFERENCE.items():
+        for name, bounds in ac.ICM40609_REFERENCE.items():
             self.assertEqual(len(bounds), 2, f"{name} bounds malformed")
             low, high = bounds
             self.assertLess(low, high, f"{name} low >= high")
             self.assertGreater(low, 0, f"{name} low non-positive")
+
+    def test_typical_values_lie_inside_range(self):
+        """Pin the table to the datasheet typicals so a future edit cannot
+        accidentally exclude the value the IMU actually produces."""
+        ac = _load_apply_calibration()
+        # Datasheet typicals (ICM-40609-D DS-000330 v1.2)
+        typicals = {
+            "na": 7e-4,    # 70 µg/√Hz × 9.81
+            "ng": 6.6e-5,  # 3.8 mdps/√Hz × π/180
+        }
+        for name, val in typicals.items():
+            low, high = ac.ICM40609_REFERENCE[name]
+            self.assertGreaterEqual(val, low, f"{name} typical {val} below low {low}")
+            self.assertLessEqual(val, high, f"{name} typical {val} above high {high}")
 
 
 if __name__ == "__main__":

--- a/src/core/tests/test_imu_noise_sanity.py
+++ b/src/core/tests/test_imu_noise_sanity.py
@@ -1,0 +1,93 @@
+"""Tests for the BMI088 IMU-noise sanity check in calibration/apply_calibration.py.
+
+The sanity check is procedural protection: Allan Variance can produce values
+that pass YAML schema but are 1-2 orders of magnitude off if the recording
+environment was wrong (vibration, thermal drift, units mis-converted). The
+default ng=0.01 currently shipping in lio.yaml is itself such a value — it
+is ~10-50x higher than BMI088 datasheet typical, and the test here locks in
+that calling the sanity check with that value warns.
+"""
+
+import importlib.util
+import logging
+import unittest
+from pathlib import Path
+
+
+def _load_apply_calibration():
+    """apply_calibration.py lives in calibration/, not src/, so it cannot be
+    imported via the normal package path. Load it directly by file path."""
+    repo_root = Path(__file__).resolve().parent.parent.parent.parent
+    path = repo_root / "calibration" / "apply_calibration.py"
+    spec = importlib.util.spec_from_file_location("apply_calibration", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestBMI088SanityCheck(unittest.TestCase):
+    def setUp(self) -> None:
+        self.ac = _load_apply_calibration()
+        self.logger_name = "apply_calibration"
+
+    def test_in_range_logs_info(self):
+        with self.assertLogs(self.logger_name, level=logging.INFO) as cm:
+            self.ac._sanity_check_imu_noise("ng", 5e-4)
+        joined = " ".join(cm.output)
+        self.assertIn("within BMI088 expected range", joined)
+        self.assertNotIn("WARNING", joined)
+
+    def test_default_ng_001_triggers_high_warning(self):
+        """The shipped default ng=0.01 must trigger the HIGH warning — this
+        is the very value the audit flagged as 10-50x off."""
+        with self.assertLogs(self.logger_name, level=logging.WARNING) as cm:
+            self.ac._sanity_check_imu_noise("ng", 0.01)
+        joined = " ".join(cm.output)
+        self.assertIn("unusually HIGH", joined)
+        self.assertIn("ng", joined)
+
+    def test_too_low_triggers_low_warning(self):
+        with self.assertLogs(self.logger_name, level=logging.WARNING) as cm:
+            self.ac._sanity_check_imu_noise("ng", 1e-7)
+        joined = " ".join(cm.output)
+        self.assertIn("unusually LOW", joined)
+
+    def test_accel_in_range(self):
+        with self.assertLogs(self.logger_name, level=logging.INFO) as cm:
+            self.ac._sanity_check_imu_noise("na", 5e-3)
+        self.assertIn("within BMI088 expected range", " ".join(cm.output))
+
+    def test_unknown_name_is_silent(self):
+        # Unknown parameter names must not raise and must not log — covers
+        # forward-compat if a future calibrator emits extra fields.
+        try:
+            self.ac._sanity_check_imu_noise("garbage_param", 1.0)
+        except Exception as e:
+            self.fail(f"sanity check raised on unknown name: {e}")
+
+    def test_threshold_is_loose_5x(self):
+        """Boundary check: values exactly at low/5 or high*5 should NOT warn,
+        only just past them should. Locks in the ±5x tolerance contract."""
+        # ng range is (2e-4, 1e-3); 5x of high = 5e-3 — boundary, no warn
+        with self.assertLogs(self.logger_name, level=logging.INFO) as cm:
+            self.ac._sanity_check_imu_noise("ng", 5e-3)
+        self.assertIn("within BMI088 expected range", " ".join(cm.output))
+
+        # 5.1e-3 — just past, warn
+        with self.assertLogs(self.logger_name, level=logging.WARNING) as cm:
+            self.ac._sanity_check_imu_noise("ng", 5.1e-3)
+        self.assertIn("unusually HIGH", " ".join(cm.output))
+
+
+class TestBMI088ReferenceTable(unittest.TestCase):
+    def test_all_keys_have_low_high_pairs(self):
+        ac = _load_apply_calibration()
+        for name, bounds in ac.BMI088_REFERENCE.items():
+            self.assertEqual(len(bounds), 2, f"{name} bounds malformed")
+            low, high = bounds
+            self.assertLess(low, high, f"{name} low >= high")
+            self.assertGreater(low, 0, f"{name} low non-positive")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/core/tests/test_localization_health.py
+++ b/src/core/tests/test_localization_health.py
@@ -323,6 +323,7 @@ class TestSlamBridgeDegeneracyParsing(unittest.TestCase):
         self.assertFalse(m._ieskf_converged)
         self.assertAlmostEqual(m._pos_cov_trace, 42.0, places=6)
 
+
     def test_severe_warning_triggers_above_cond_threshold(self):
         """condition_number > 1e6 triggers a throttled SEVERE warning."""
         import logging
@@ -400,6 +401,62 @@ class TestSlamBridgeDegeneracyParsing(unittest.TestCase):
 
         m._on_rclpy_odom(msg)
         self.assertAlmostEqual(m._max_pos_cov, 150.0, places=3)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# P3: localizer-side multi-frame health (/nav/localization_health subscription)
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestSlamBridgeLocalizerHealth(unittest.TestCase):
+    """P3: parse multi-frame confirmed localizer health from
+    /nav/localization_health String topic."""
+
+    def _make(self):
+        from slam.slam_bridge_module import SlamBridgeModule
+        return SlamBridgeModule(watchdog_hz=100)
+
+    def _msg(self, data):
+        class _M:
+            pass
+        m = _M()
+        m.data = data
+        return m
+
+    def test_initial_health_is_unknown(self):
+        m = self._make()
+        self.assertEqual(m._localizer_health, "UNKNOWN")
+        self.assertEqual(m._localizer_health_fitness, 0.0)
+
+    def test_locked_payload_parsed(self):
+        m = self._make()
+        m._on_rclpy_localization_health(self._msg("LOCKED|fitness=0.0234"))
+        self.assertEqual(m._localizer_health, "LOCKED")
+        self.assertAlmostEqual(m._localizer_health_fitness, 0.0234, places=4)
+
+    def test_lost_payload_parsed(self):
+        m = self._make()
+        m._on_rclpy_localization_health(self._msg("LOST|fitness=0.45"))
+        self.assertEqual(m._localizer_health, "LOST")
+        self.assertAlmostEqual(m._localizer_health_fitness, 0.45, places=4)
+
+    def test_recovered_payload_parsed(self):
+        m = self._make()
+        m._on_rclpy_localization_health(self._msg("RECOVERED|fitness=0.05"))
+        self.assertEqual(m._localizer_health, "RECOVERED")
+
+    def test_payload_without_fitness_keeps_state(self):
+        """Defensive: payload missing the |fitness=... suffix should still
+        update state without raising."""
+        m = self._make()
+        m._localizer_health_fitness = 0.1
+        m._on_rclpy_localization_health(self._msg("LOST"))
+        self.assertEqual(m._localizer_health, "LOST")
+        self.assertAlmostEqual(m._localizer_health_fitness, 0.1, places=4)
+
+    def test_malformed_payload_does_not_crash(self):
+        m = self._make()
+        m._on_rclpy_localization_health(self._msg("garbage|fitness=NaN"))
+        self.assertEqual(m._localizer_health, "GARBAGE")
 
 
 # ──────────────────────────────────────────────────────────────────────────────

--- a/src/core/tests/test_localization_health.py
+++ b/src/core/tests/test_localization_health.py
@@ -459,6 +459,64 @@ class TestSlamBridgeLocalizerHealth(unittest.TestCase):
         self.assertEqual(m._localizer_health, "GARBAGE")
 
 
+class TestSlamBridgeTFJumpDetection(unittest.TestCase):
+    """P4: detect map↔odom TF discontinuities and publish events."""
+
+    def _make(self, **kw):
+        from slam.slam_bridge_module import SlamBridgeModule
+        defaults = {"jump_t_threshold_m": 1.0, "jump_r_threshold_deg": 30.0}
+        defaults.update(kw)
+        return SlamBridgeModule(watchdog_hz=100, **defaults)
+
+    def test_first_call_does_not_emit_jump(self):
+        """No baseline → cannot diff → first call must NOT emit a jump event."""
+        m = self._make()
+        events = []
+        m.map_frame_jump_event._add_callback(events.append)
+        m._cache_map_odom_tf(0, 0, 0, 0, 0, 0, 1)
+        self.assertEqual(len(events), 0)
+
+    def test_small_translation_does_not_emit(self):
+        m = self._make()
+        events = []
+        m._cache_map_odom_tf(0, 0, 0, 0, 0, 0, 1)
+        m.map_frame_jump_event._add_callback(events.append)
+        m._cache_map_odom_tf(0.1, 0.1, 0, 0, 0, 0, 1)  # √0.02 ≈ 0.14m
+        self.assertEqual(len(events), 0)
+
+    def test_large_translation_emits_jump(self):
+        m = self._make()
+        events = []
+        m._cache_map_odom_tf(0, 0, 0, 0, 0, 0, 1)
+        m.map_frame_jump_event._add_callback(events.append)
+        m._cache_map_odom_tf(2.0, 0, 0, 0, 0, 0, 1)  # 2m jump > 1m threshold
+        self.assertEqual(len(events), 1)
+        evt = events[0]
+        self.assertGreater(evt["dt_m"], 1.0)
+        self.assertEqual(evt["new_xyz"], [2.0, 0.0, 0.0])
+
+    def test_large_rotation_emits_jump(self):
+        """A 60° yaw jump (no translation) should still emit even though Δt=0."""
+        import math
+        m = self._make()
+        events = []
+        m._cache_map_odom_tf(0, 0, 0, 0, 0, 0, 1)  # identity
+        m.map_frame_jump_event._add_callback(events.append)
+        # 60° yaw rotation as quaternion
+        half = math.radians(60.0) / 2.0
+        m._cache_map_odom_tf(0, 0, 0, 0, 0, math.sin(half), math.cos(half))
+        self.assertEqual(len(events), 1)
+        self.assertGreater(events[0]["dyaw_deg"], 30.0)
+
+    def test_threshold_overrides_via_kw(self):
+        m = self._make(jump_t_threshold_m=10.0)  # very loose
+        events = []
+        m._cache_map_odom_tf(0, 0, 0, 0, 0, 0, 1)
+        m.map_frame_jump_event._add_callback(events.append)
+        m._cache_map_odom_tf(2.0, 0, 0, 0, 0, 0, 1)  # 2m, well below 10m
+        self.assertEqual(len(events), 0)
+
+
 # ──────────────────────────────────────────────────────────────────────────────
 # SafetyRingModule localization tests
 # ──────────────────────────────────────────────────────────────────────────────

--- a/src/core/tests/test_localization_health.py
+++ b/src/core/tests/test_localization_health.py
@@ -167,6 +167,42 @@ class TestSlamBridgeDegeneracyParsing(unittest.TestCase):
         self.assertEqual(m._degenerate_dof_count, 2)
         self.assertEqual(m._dof_mask.tolist(), [1.0, 1.0, 0.0, 0.0, 1.0, 1.0])
 
+    def test_legacy_11_field_payload_keeps_iekf_defaults(self):
+        """Old fastlio2 publishers emit only 11 floats; new IEKF state stays default."""
+        m = self._make()
+        msg = self._make_msg(cond=10.0, min_eig=0.5, max_eig=5.0,
+                             eff_ratio=0.9, degen_count=0,
+                             mask=[1, 1, 1, 1, 1, 1])
+        # Sanity check: this is the legacy 11-float layout.
+        self.assertEqual(len(msg.data), 11)
+        m._on_rclpy_degeneracy_detail(msg)
+        self.assertEqual(m._pos_cov_trace, 0.0)
+        self.assertEqual(m._ieskf_iter_num, 0)
+        self.assertTrue(m._ieskf_converged)
+
+    def test_extended_14_field_payload_populates_iekf_diagnostics(self):
+        """New fastlio2 publishers append [pos_cov_trace, iter_num, converged]."""
+        m = self._make()
+        msg = self._make_msg(cond=10.0, min_eig=0.5, max_eig=5.0,
+                             eff_ratio=0.9, degen_count=0,
+                             mask=[1, 1, 1, 1, 1, 1])
+        msg.data = list(msg.data) + [0.123, 7.0, 1.0]  # extend to 14
+        m._on_rclpy_degeneracy_detail(msg)
+        self.assertAlmostEqual(m._pos_cov_trace, 0.123, places=6)
+        self.assertEqual(m._ieskf_iter_num, 7)
+        self.assertTrue(m._ieskf_converged)
+
+    def test_extended_payload_marks_non_convergence(self):
+        """converged < 0.5 in slot 13 flips _ieskf_converged to False."""
+        m = self._make()
+        msg = self._make_msg(cond=10.0, min_eig=0.5, max_eig=5.0,
+                             eff_ratio=0.9, degen_count=0,
+                             mask=[1, 1, 1, 1, 1, 1])
+        msg.data = list(msg.data) + [42.0, 5.0, 0.0]
+        m._on_rclpy_degeneracy_detail(msg)
+        self.assertFalse(m._ieskf_converged)
+        self.assertAlmostEqual(m._pos_cov_trace, 42.0, places=6)
+
     def test_severe_warning_triggers_above_cond_threshold(self):
         """condition_number > 1e6 triggers a throttled SEVERE warning."""
         import logging

--- a/src/core/tests/test_localization_health.py
+++ b/src/core/tests/test_localization_health.py
@@ -127,6 +127,126 @@ class TestSlamBridgeWatchdog(unittest.TestCase):
         m.stop()  # Should not raise
 
 
+class TestSlamBridgeFallbackTransition(unittest.TestCase):
+    """LOC_DEGRADED → LOC_FALLBACK_GNSS_ONLY promotion when GNSS is healthy.
+
+    Wires the state machine half. The actual GNSS+IMU dead-reckoning takeover
+    lands in S2.5 once fault-injection tooling exists; these tests lock in
+    that the transition fires under the right preconditions and reverts on
+    SLAM recovery.
+    """
+
+    def _make(self, **kw):
+        from slam.slam_bridge_module import SlamBridgeModule
+        defaults = {
+            "odom_timeout": 0.1,
+            "cloud_timeout": 0.2,
+            "watchdog_hz": 50,
+            "fallback_after_degraded_s": 0.05,  # short for unit test
+            "gnss_max_age_for_fallback_s": 1.0,
+        }
+        defaults.update(kw)
+        return SlamBridgeModule(**defaults)
+
+    def _stub_healthy_gnss(self, m):
+        """Plant a fresh RTK_FIXED GnssOdom directly so the watchdog sees
+        GNSS as healthy without spinning up the GNSS subscription path."""
+        from core.msgs.gnss import GnssFixType, GnssOdom
+        m._last_gnss_odom = GnssOdom(
+            east=0.0, north=0.0, up=0.0, ve=0.0, vn=0.0, vu=0.0,
+            cov_e=0.01, cov_n=0.01, cov_u=0.04,
+            fix_type=GnssFixType.RTK_FIXED, ts=time.time(),
+        )
+        m._last_gnss_rx_ts = time.time()
+
+    def test_degraded_promotes_to_fallback_when_gnss_healthy(self):
+        m = self._make()
+        received = []
+        m.localization_status._add_callback(received.append)
+        m.start()
+        # Force DEGRADED by leaving cloud stale, odom fresh.
+        self._stub_healthy_gnss(m)
+        m._last_odom_time = time.time()
+        m._last_cloud_time = time.time() - 0.5
+        # Hold long enough to clear fallback_after_degraded_s.
+        time.sleep(0.15)
+        m.stop()
+        states = [r["state"] for r in received]
+        self.assertIn("FALLBACK_GNSS_ONLY", states,
+                      f"Expected fallback transition, saw: {set(states)}")
+
+    def test_degraded_stays_degraded_without_gnss(self):
+        m = self._make()
+        received = []
+        m.localization_status._add_callback(received.append)
+        m.start()
+        # No GNSS planted → fallback gate must keep us at DEGRADED.
+        m._last_odom_time = time.time()
+        m._last_cloud_time = time.time() - 0.5
+        time.sleep(0.15)
+        m.stop()
+        states = [r["state"] for r in received]
+        self.assertIn("DEGRADED", states)
+        self.assertNotIn("FALLBACK_GNSS_ONLY", states)
+
+    def test_degraded_stays_degraded_with_stale_gnss(self):
+        m = self._make()
+        received = []
+        m.localization_status._add_callback(received.append)
+        m.start()
+        # GNSS rx > gnss_max_age_for_fallback_s → fallback gate closed.
+        self._stub_healthy_gnss(m)
+        m._last_gnss_rx_ts = time.time() - 5.0  # stale
+        m._last_odom_time = time.time()
+        m._last_cloud_time = time.time() - 0.5
+        time.sleep(0.15)
+        m.stop()
+        states = [r["state"] for r in received]
+        self.assertNotIn("FALLBACK_GNSS_ONLY", states)
+
+    def test_degraded_stays_degraded_when_only_single_fix(self):
+        """Single-point GNSS isn't precise enough to anchor on."""
+        m = self._make()
+        received = []
+        m.localization_status._add_callback(received.append)
+        m.start()
+        from core.msgs.gnss import GnssFixType, GnssOdom
+        m._last_gnss_odom = GnssOdom(
+            east=0.0, north=0.0, up=0.0, ve=0.0, vn=0.0, vu=0.0,
+            cov_e=0.5, cov_n=0.5, cov_u=1.0,
+            fix_type=GnssFixType.SINGLE, ts=time.time(),
+        )
+        m._last_gnss_rx_ts = time.time()
+        m._last_odom_time = time.time()
+        m._last_cloud_time = time.time() - 0.5
+        time.sleep(0.15)
+        m.stop()
+        states = [r["state"] for r in received]
+        self.assertNotIn("FALLBACK_GNSS_ONLY", states)
+
+    def test_recovery_from_fallback_back_to_tracking(self):
+        m = self._make()
+        received = []
+        m.localization_status._add_callback(received.append)
+        m.start()
+        self._stub_healthy_gnss(m)
+        m._last_odom_time = time.time()
+        m._last_cloud_time = time.time() - 0.5
+        time.sleep(0.15)  # enter FALLBACK
+        # Now restore both odom and cloud freshness — keep them fresh while we
+        # observe recovery so the watchdog does not race us into LOST.
+        for _ in range(20):
+            m._last_odom_time = time.time()
+            m._last_cloud_time = time.time()
+            time.sleep(0.01)
+        m.stop()
+        states = [r["state"] for r in received]
+        self.assertIn("FALLBACK_GNSS_ONLY", states)
+        # After recovery, TRACKING should appear after the FALLBACK index.
+        fb_idx = max(i for i, s in enumerate(states) if s == "FALLBACK_GNSS_ONLY")
+        self.assertIn("TRACKING", states[fb_idx + 1:])
+
+
 # ──────────────────────────────────────────────────────────────────────────────
 # SlamBridgeModule degeneracy parsing + covariance tracking
 # ──────────────────────────────────────────────────────────────────────────────
@@ -607,6 +727,24 @@ class TestNavigationDegeneracyResponse(unittest.TestCase):
             "degeneracy": "NONE",
         })
         self.assertAlmostEqual(m._speed_scale, 1.0)
+
+    def test_fallback_gnss_only_caps_speed_below_severe(self):
+        """FALLBACK is a more cautious mode than DEGEN SEVERE — slower scale."""
+        m, _MS = self._make()
+        m._on_localization_status({
+            "state": "FALLBACK_GNSS_ONLY", "confidence": 0.4,
+            "degeneracy": "SEVERE",
+        })
+        self.assertAlmostEqual(m._speed_scale, 0.3)
+
+    def test_fallback_overrides_mild_degeneracy(self):
+        """Even if degeneracy is only MILD, FALLBACK state forces 0.3x."""
+        m, _MS = self._make()
+        m._on_localization_status({
+            "state": "FALLBACK_GNSS_ONLY", "confidence": 0.4,
+            "degeneracy": "MILD",
+        })
+        self.assertAlmostEqual(m._speed_scale, 0.3)
 
 
 if __name__ == "__main__":

--- a/src/core/tests/test_localization_health.py
+++ b/src/core/tests/test_localization_health.py
@@ -458,6 +458,47 @@ class TestSlamBridgeLocalizerHealth(unittest.TestCase):
         m._on_rclpy_localization_health(self._msg("garbage|fitness=NaN"))
         self.assertEqual(m._localizer_health, "GARBAGE")
 
+    def test_r4_extended_payload_parses_iter_and_cov(self):
+        """R4: small_gicp adds iter + cov fields. Parser must pick them up
+        for downstream three-axis health gating."""
+        m = self._make()
+        m._on_rclpy_localization_health(
+            self._msg("LOCKED|fitness=0.0234|iter=8|cov=0.12"))
+        self.assertEqual(m._localizer_health, "LOCKED")
+        self.assertAlmostEqual(m._localizer_health_fitness, 0.0234, places=4)
+        self.assertEqual(m._localizer_health_iter, 8)
+        self.assertAlmostEqual(m._localizer_health_cov_trace, 0.12, places=4)
+
+    def test_r4_v1_payload_keeps_iter_and_cov_at_default(self):
+        """Backward-compat: a robot still publishing the v1 P3 payload
+        (no iter / no cov) must NOT raise and must keep the iter/cov
+        fields at their -1 sentinel."""
+        m = self._make()
+        m._on_rclpy_localization_health(self._msg("LOCKED|fitness=0.05"))
+        self.assertEqual(m._localizer_health, "LOCKED")
+        self.assertEqual(m._localizer_health_iter, -1)
+        self.assertEqual(m._localizer_health_cov_trace, -1.0)
+
+    def test_r4_unknown_keys_ignored(self):
+        """Forward-compat: future localizer payload may add keys we don't
+        know yet; parser must skip them silently without affecting known
+        fields."""
+        m = self._make()
+        m._on_rclpy_localization_health(
+            self._msg("LOCKED|fitness=0.05|iter=3|cov=0.01|future_key=42"))
+        self.assertEqual(m._localizer_health_iter, 3)
+        self.assertAlmostEqual(m._localizer_health_cov_trace, 0.01, places=4)
+
+    def test_r4_field_order_independent(self):
+        """Keys after the leading state must be order-independent."""
+        m = self._make()
+        m._on_rclpy_localization_health(
+            self._msg("LOST|cov=5.5|iter=10|fitness=0.4"))
+        self.assertEqual(m._localizer_health, "LOST")
+        self.assertEqual(m._localizer_health_iter, 10)
+        self.assertAlmostEqual(m._localizer_health_fitness, 0.4, places=4)
+        self.assertAlmostEqual(m._localizer_health_cov_trace, 5.5, places=4)
+
 
 class TestSlamBridgeTFJumpDetection(unittest.TestCase):
     """P4: detect map↔odom TF discontinuities and publish events."""

--- a/src/core/tests/test_scene_mode_detector.py
+++ b/src/core/tests/test_scene_mode_detector.py
@@ -1,0 +1,117 @@
+"""Tests for core.utils.scene_mode_detector — indoor/outdoor classification."""
+
+import os
+import unittest
+from unittest.mock import patch
+
+from core.utils.scene_mode_detector import (
+    MODE_INDOOR, MODE_OUTDOOR, MODE_UNKNOWN,
+    SceneModeConfig, SceneModeDetector,
+)
+
+
+class TestInitialState(unittest.TestCase):
+    def test_default_is_unknown(self):
+        d = SceneModeDetector()
+        self.assertEqual(d.mode, MODE_UNKNOWN)
+        self.assertEqual(d.source, "init")
+
+    def test_env_var_indoor_takes_effect(self):
+        with patch.dict(os.environ, {"LINGTU_SCENE_MODE": "indoor"}):
+            d = SceneModeDetector()
+            self.assertEqual(d.mode, MODE_INDOOR)
+            self.assertEqual(d.source, "manual")
+
+    def test_env_var_invalid_is_ignored(self):
+        with patch.dict(os.environ, {"LINGTU_SCENE_MODE": "garbage"}):
+            d = SceneModeDetector()
+            self.assertEqual(d.mode, MODE_UNKNOWN)
+
+
+class TestManualOverride(unittest.TestCase):
+    def test_set_indoor_overrides_auto(self):
+        d = SceneModeDetector(SceneModeConfig(hold_seconds=0.0))
+        # Two observations needed to seed candidate then confirm.
+        d.observe_gnss("RTK_FIXED", age_s=0.1, now=100.0)
+        d.observe_gnss("RTK_FIXED", age_s=0.1, now=100.1)
+        self.assertEqual(d.mode, MODE_OUTDOOR)
+        # Manual indoor wins
+        d.set_manual_mode(MODE_INDOOR)
+        self.assertEqual(d.mode, MODE_INDOOR)
+        self.assertEqual(d.source, "manual")
+
+    def test_clear_manual_falls_back_to_auto(self):
+        d = SceneModeDetector(SceneModeConfig(hold_seconds=0.0))
+        d.observe_gnss("RTK_FIXED", age_s=0.1, now=100.0)
+        d.observe_gnss("RTK_FIXED", age_s=0.1, now=100.1)
+        d.set_manual_mode(MODE_INDOOR)
+        d.set_manual_mode(None)
+        self.assertEqual(d.mode, MODE_OUTDOOR)
+        self.assertEqual(d.source, "auto")
+
+    def test_invalid_manual_mode_raises(self):
+        d = SceneModeDetector()
+        with self.assertRaises(ValueError):
+            d.set_manual_mode("garbage")
+
+
+class TestAutoDetection(unittest.TestCase):
+    def test_rtk_fixed_with_hold_flips_to_outdoor(self):
+        d = SceneModeDetector(SceneModeConfig(hold_seconds=5.0))
+        # Same observation under hold_seconds → still UNKNOWN
+        flipped = d.observe_gnss("RTK_FIXED", age_s=0.1, now=100.0)
+        self.assertFalse(flipped)
+        self.assertEqual(d.mode, MODE_UNKNOWN)
+        # 5s later → flips
+        flipped = d.observe_gnss("RTK_FIXED", age_s=0.1, now=105.0)
+        self.assertTrue(flipped)
+        self.assertEqual(d.mode, MODE_OUTDOOR)
+
+    def test_no_fix_flips_to_indoor(self):
+        d = SceneModeDetector(SceneModeConfig(hold_seconds=2.0))
+        d.observe_gnss("NO_FIX", age_s=0.1, now=100.0)
+        d.observe_gnss("NO_FIX", age_s=0.1, now=103.0)
+        self.assertEqual(d.mode, MODE_INDOOR)
+
+    def test_stale_gnss_counts_as_indoor(self):
+        d = SceneModeDetector(SceneModeConfig(hold_seconds=2.0, gnss_max_age_s=2.0))
+        # RTK_FIXED but age too high → indoor evidence
+        d.observe_gnss("RTK_FIXED", age_s=5.0, now=100.0)
+        d.observe_gnss("RTK_FIXED", age_s=5.0, now=103.0)
+        self.assertEqual(d.mode, MODE_INDOOR)
+
+    def test_flip_resets_hysteresis(self):
+        """Auto flips to OUTDOOR after 5s, then a single NO_FIX restarts the
+        hysteresis timer for INDOOR — does not flip immediately."""
+        d = SceneModeDetector(SceneModeConfig(hold_seconds=5.0))
+        d.observe_gnss("RTK_FIXED", age_s=0.1, now=100.0)
+        d.observe_gnss("RTK_FIXED", age_s=0.1, now=106.0)  # OUTDOOR
+        self.assertEqual(d.mode, MODE_OUTDOOR)
+        # Single NO_FIX — does not flip yet
+        flipped = d.observe_gnss("NO_FIX", age_s=0.1, now=107.0)
+        self.assertFalse(flipped)
+        self.assertEqual(d.mode, MODE_OUTDOOR)
+        # 5s of consistent NO_FIX → flip
+        flipped = d.observe_gnss("NO_FIX", age_s=0.1, now=112.5)
+        self.assertTrue(flipped)
+        self.assertEqual(d.mode, MODE_INDOOR)
+
+    def test_observe_no_gnss_is_indoor_evidence(self):
+        d = SceneModeDetector(SceneModeConfig(hold_seconds=2.0))
+        d.observe_no_gnss(now=100.0)
+        d.observe_no_gnss(now=103.0)
+        self.assertEqual(d.mode, MODE_INDOOR)
+
+
+class TestRequireRtkFlag(unittest.TestCase):
+    def test_require_rtk_off_accepts_single_fix(self):
+        d = SceneModeDetector(SceneModeConfig(hold_seconds=2.0, require_rtk=False))
+        d.observe_gnss("SINGLE", age_s=0.1, now=100.0)
+        d.observe_gnss("SINGLE", age_s=0.1, now=103.0)
+        # Without require_rtk, SINGLE counts as outdoor; we used the fall-through
+        # else branch which classifies anything not NO_FIX / stale as outdoor.
+        self.assertEqual(d.mode, MODE_OUTDOOR)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/core/utils/blackbox_recorder.py
+++ b/src/core/utils/blackbox_recorder.py
@@ -1,0 +1,187 @@
+"""BlackBoxRecorder — ring-buffer crash recorder for the SLAM drift watchdog.
+
+When the drift watchdog tears down a diverged SLAM stack, the only trace left
+behind today is a single SSE event with `xy` and `v`. By the time an operator
+notices the crash, the only artefact is "we restarted at 13:42 because xy=8e6".
+That is not enough to attribute the divergence: was it a long static stretch,
+a step-pattern IMU pulse, a GNSS jump that jerked the alignment lock, or a
+LiDAR drop-out?
+
+This recorder maintains short ring buffers of the streams that flow through
+the gateway (odometry, slam_diag, gnss_fusion, map_odom_tf) and dumps them as
+JSONL files when the watchdog trips. The dumps go to a configurable directory
+under ~/data/slam/crashes/ and are GC'd to a fixed retention so they do not
+bloat the disk.
+
+The recorder is intentionally agnostic about ROS, drivers, or transport — any
+caller can `record(channel, value)` from any thread and `dump(reason)` to
+flush. JSON-encoding is best-effort: numpy arrays are converted via
+``.tolist()`` and non-serialisable values fall back to ``repr()``.
+
+Configuration via environment variables (read by ``BlackBoxRecorder.from_env``):
+
+* ``LINGTU_BLACKBOX_ENABLED``       — "0" disables; default enabled.
+* ``LINGTU_BLACKBOX_DIR``           — base directory; default ``~/data/slam/crashes``.
+* ``LINGTU_BLACKBOX_MAX_PER_CHANNEL``— ring-buffer depth; default 600 (≈60 s @10 Hz).
+* ``LINGTU_BLACKBOX_RETENTION``     — number of dump directories to keep; default 20.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import socket
+import threading
+import time
+from collections import defaultdict, deque
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _json_default(obj: Any) -> Any:
+    """Best-effort fallback for objects ``json.dumps`` cannot encode natively."""
+    # numpy is ubiquitous in this codebase but optional in test environments
+    try:
+        import numpy as np  # local import — avoid forcing numpy on consumers
+        if isinstance(obj, np.ndarray):
+            return obj.tolist()
+        if isinstance(obj, (np.integer,)):
+            return int(obj)
+        if isinstance(obj, (np.floating,)):
+            return float(obj)
+    except ImportError:
+        pass
+    if hasattr(obj, "__dict__"):
+        return {"__type__": type(obj).__name__, "repr": repr(obj)}
+    return repr(obj)
+
+
+class BlackBoxRecorder:
+    """Thread-safe per-channel ring buffer with on-demand crash dumps."""
+
+    def __init__(
+        self,
+        base_dir: Path,
+        max_per_channel: int = 600,
+        retention: int = 20,
+        enabled: bool = True,
+    ) -> None:
+        self.base_dir = Path(base_dir)
+        self.max_per_channel = int(max_per_channel)
+        self.retention = int(retention)
+        self.enabled = bool(enabled)
+        self._buffers: dict[str, deque[tuple[float, Any]]] = defaultdict(
+            lambda: deque(maxlen=self.max_per_channel)
+        )
+        self._lock = threading.Lock()
+        if self.enabled:
+            try:
+                self.base_dir.mkdir(parents=True, exist_ok=True)
+            except OSError as e:
+                # Disable rather than crash the gateway if the path is unwritable.
+                logger.warning(
+                    "BlackBoxRecorder: cannot create %s (%s) — disabling",
+                    self.base_dir, e,
+                )
+                self.enabled = False
+
+    @classmethod
+    def from_env(cls) -> "BlackBoxRecorder":
+        enabled = os.environ.get("LINGTU_BLACKBOX_ENABLED", "1") != "0"
+        base = Path(os.environ.get(
+            "LINGTU_BLACKBOX_DIR",
+            str(Path.home() / "data" / "slam" / "crashes"),
+        ))
+        max_per_ch = int(os.environ.get("LINGTU_BLACKBOX_MAX_PER_CHANNEL", "600"))
+        retention = int(os.environ.get("LINGTU_BLACKBOX_RETENTION", "20"))
+        return cls(base, max_per_channel=max_per_ch, retention=retention, enabled=enabled)
+
+    # ── recording ─────────────────────────────────────────────────────────
+
+    def record(self, channel: str, value: Any) -> None:
+        """Append ``value`` to the ``channel`` ring buffer. Thread-safe.
+
+        Cheap path when disabled — early return to keep callback hot loops fast.
+        """
+        if not self.enabled:
+            return
+        ts = time.time()
+        with self._lock:
+            self._buffers[channel].append((ts, value))
+
+    # ── dumping ───────────────────────────────────────────────────────────
+
+    def dump(self, reason: str, metadata: Optional[dict] = None) -> Optional[Path]:
+        """Flush all ring buffers to ``base_dir/drift_<ts>/`` as JSONL files.
+
+        Returns the dump directory path so the caller can attach it to whatever
+        crash event it emits (so operators can ``cd`` straight to the artefact).
+        Returns ``None`` if disabled or on I/O failure.
+        """
+        if not self.enabled:
+            return None
+        ts = time.time()
+        out = self.base_dir / f"drift_{int(ts)}"
+        try:
+            out.mkdir(parents=True, exist_ok=True)
+            meta = {
+                "timestamp": ts,
+                "iso_timestamp": time.strftime("%Y-%m-%dT%H:%M:%S",
+                                                time.gmtime(ts)) + "Z",
+                "reason": reason,
+                "hostname": socket.gethostname(),
+            }
+            if metadata:
+                meta.update(metadata)
+            (out / "metadata.json").write_text(
+                json.dumps(meta, indent=2, default=_json_default))
+
+            with self._lock:
+                snapshots = {name: list(buf) for name, buf in self._buffers.items()}
+
+            for name, buf in snapshots.items():
+                lines = [
+                    json.dumps({"t": t, "v": v}, default=_json_default)
+                    for t, v in buf
+                ]
+                (out / f"{name}.jsonl").write_text("\n".join(lines) + "\n" if lines else "")
+        except OSError as e:
+            logger.error("BlackBoxRecorder: dump failed: %s", e)
+            return None
+
+        self._gc()
+        logger.info("BlackBoxRecorder: dumped %d channels to %s",
+                    len(snapshots), out)
+        return out
+
+    def _gc(self) -> None:
+        """Keep only the most recent ``retention`` dump directories."""
+        try:
+            dirs = sorted(
+                (p for p in self.base_dir.iterdir()
+                 if p.is_dir() and p.name.startswith("drift_")),
+                key=lambda p: p.stat().st_mtime,
+                reverse=True,
+            )
+        except OSError:
+            return
+        for stale in dirs[self.retention:]:
+            try:
+                for f in stale.iterdir():
+                    f.unlink()
+                stale.rmdir()
+            except OSError as e:
+                logger.debug("BlackBoxRecorder: gc %s failed: %s", stale, e)
+
+    # ── introspection (testing) ───────────────────────────────────────────
+
+    def channels(self) -> list[str]:
+        with self._lock:
+            return list(self._buffers.keys())
+
+    def buffer_size(self, channel: str) -> int:
+        with self._lock:
+            return len(self._buffers.get(channel, ()))

--- a/src/core/utils/calibration_check.py
+++ b/src/core/utils/calibration_check.py
@@ -26,6 +26,12 @@ logger = logging.getLogger(__name__)
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
 FASTLIO2_CONFIG = REPO_ROOT / "src" / "slam" / "fastlio2" / "config" / "lio.yaml"
+POINTLIO_CONFIG = REPO_ROOT / "config" / "pointlio.yaml"
+
+# Plausible LiDAR↔IMU clock offset range (seconds). Hardware-synchronised systems
+# typically calibrate to <10 ms; values beyond this likely indicate a parsing bug
+# or hardware sync failure.
+TIME_OFFSET_MAX_ABS_S = 0.1
 
 
 @dataclass
@@ -82,6 +88,7 @@ def run_calibration_check(
     _check_depth_scale(config, report)
     _check_lidar_imu_consistency(config, report, require_slam)
     _check_rotation_validity(report)
+    _check_time_offset(report, require_slam)
 
     # Log results
     for msg in report.errors:
@@ -254,6 +261,84 @@ def _check_lidar_imu_consistency(
         report.warnings.append(
             f"High IMU noise: na={na}, ng={ng} — consider Allan variance calibration"
         )
+
+
+def _extract_pointlio_time_offset() -> Optional[float]:
+    """Read time_diff_lidar_to_imu from pointlio.yaml.
+
+    Supports both ROS2 parameter file layout (`/** -> ros__parameters -> common`)
+    and flat-key layout. Returns None if missing/unreadable.
+    """
+    if not POINTLIO_CONFIG.exists():
+        return None
+    try:
+        import yaml
+        with open(POINTLIO_CONFIG) as f:
+            pl = yaml.safe_load(f) or {}
+    except Exception:
+        return None
+
+    # Search common locations in priority order.
+    for node in (
+        pl,
+        pl.get("/**", {}).get("ros__parameters", {}).get("common", {})
+            if isinstance(pl.get("/**"), dict) else {},
+        pl.get("common", {}) if isinstance(pl.get("common"), dict) else {},
+        pl.get("ros__parameters", {}).get("common", {})
+            if isinstance(pl.get("ros__parameters"), dict) else {},
+    ):
+        if isinstance(node, dict) and "time_diff_lidar_to_imu" in node:
+            try:
+                return float(node["time_diff_lidar_to_imu"])
+            except (TypeError, ValueError):
+                return None
+    return None
+
+
+def _check_time_offset(report: CalibrationReport, required: bool) -> None:
+    """Validate LiDAR↔IMU time offset is within physical range and consistent
+    between fastlio2 and pointlio configs."""
+    import yaml
+
+    lio_offset = None
+    if FASTLIO2_CONFIG.exists():
+        try:
+            with open(FASTLIO2_CONFIG) as f:
+                lio = yaml.safe_load(f) or {}
+            lio_offset = lio.get("time_diff_lidar_to_imu")
+        except Exception:
+            pass
+
+    pointlio_offset = _extract_pointlio_time_offset()
+
+    for name, val in (("lio.yaml", lio_offset), ("pointlio.yaml", pointlio_offset)):
+        if val is None:
+            continue
+        if abs(val) > TIME_OFFSET_MAX_ABS_S:
+            msg = (
+                f"{name} time_diff_lidar_to_imu = {val:.6f}s exceeds plausible "
+                f"±{TIME_OFFSET_MAX_ABS_S}s range — calibration likely wrong"
+            )
+            if required:
+                report.errors.append(msg)
+            else:
+                report.warnings.append(msg)
+
+    if lio_offset is not None and pointlio_offset is not None:
+        if abs(lio_offset - pointlio_offset) > 1e-4:
+            msg = (
+                f"time_diff_lidar_to_imu mismatch: lio.yaml={lio_offset:.6f}s "
+                f"vs pointlio.yaml={pointlio_offset:.6f}s. "
+                "Run: python calibration/apply_calibration.py to sync."
+            )
+            if required:
+                report.errors.append(msg)
+            else:
+                report.warnings.append(msg)
+        else:
+            report.info.append(
+                f"time_diff_lidar_to_imu consistent across configs ({lio_offset:.6f}s)"
+            )
 
 
 def _check_rotation_validity(report: CalibrationReport) -> None:

--- a/src/core/utils/scene_mode_detector.py
+++ b/src/core/utils/scene_mode_detector.py
@@ -1,0 +1,164 @@
+"""SceneModeDetector — runtime indoor / outdoor classification for SLAM gating.
+
+Why this exists
+---------------
+LingTu deploys to **both indoor and outdoor** environments (~50/50). The two
+have different optimal SLAM strategies:
+
+* **Outdoor**: GNSS Factor in PGO is the dominant global anchor; map↔ENU
+  Kabsch yaw alignment is necessary; speed limits more permissive.
+* **Indoor**: GNSS unavailable, so Scan Context loop closure (N1) is the
+  only global anchor; tighter speed limits because no absolute reference.
+
+Hard-coding either strategy gives bad behaviour in the other regime. We
+need a runtime mode switch with two channels:
+
+1. **Manual** override via env / API (the user knows the deployment).
+2. **Auto** detection from GNSS health (sustained RTK_FIXED → outdoor;
+   sustained NO_FIX → indoor).
+
+This module owns *only* the classification logic, not the wiring. The
+SlamBridgeModule feeds GnssOdom samples and reads the current mode; other
+modules subscribe through a port for state-change notifications.
+
+Mode states
+-----------
+* ``outdoor`` — GNSS factor active, Kabsch yaw alignment running.
+* ``indoor``  — GNSS factor disabled, Scan Context primary, tighter speed.
+* ``unknown`` — initial state until enough samples accumulate (~5 s default).
+
+Hysteresis
+----------
+Auto detection requires ``hold_seconds`` of consistent observations before
+flipping. Otherwise a single GNSS dropout (shadow under a tree) would flap
+the mode and unnecessarily reconfigure the SLAM stack.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+MODE_INDOOR = "indoor"
+MODE_OUTDOOR = "outdoor"
+MODE_UNKNOWN = "unknown"
+
+VALID_MODES = (MODE_INDOOR, MODE_OUTDOOR, MODE_UNKNOWN)
+
+
+@dataclass
+class SceneModeConfig:
+    # Auto-detect hold time before flipping mode (seconds).
+    hold_seconds: float = 5.0
+    # GNSS sample max age to consider for outdoor classification.
+    gnss_max_age_s: float = 2.0
+    # Only RTK_FIXED / RTK_FLOAT count toward "outdoor" evidence.
+    require_rtk: bool = True
+
+
+class SceneModeDetector:
+    """Classify deployment as indoor / outdoor with hysteresis + manual override.
+
+    Manual override sources, in priority order:
+    1. ``set_manual_mode("indoor"|"outdoor"|None)`` — runtime API
+    2. ``LINGTU_SCENE_MODE`` env var — set at process start
+    3. Auto detection (default).
+
+    A manual override of None falls back to auto.
+    """
+
+    def __init__(self, config: Optional[SceneModeConfig] = None) -> None:
+        self.config = config or SceneModeConfig()
+        env_mode = os.environ.get("LINGTU_SCENE_MODE", "").strip().lower() or None
+        if env_mode and env_mode not in VALID_MODES:
+            logger.warning(
+                "LINGTU_SCENE_MODE=%r is not one of %s — ignoring", env_mode, VALID_MODES)
+            env_mode = None
+        self._manual: Optional[str] = env_mode if env_mode in (MODE_INDOOR, MODE_OUTDOOR) else None
+        self._auto_mode: str = MODE_UNKNOWN
+        # Wall-clock of the most recent observation that *agreed* with the
+        # currently-pending candidate. Together with config.hold_seconds this
+        # implements the flip hysteresis.
+        self._candidate_mode: str = MODE_UNKNOWN
+        self._candidate_since_ts: float = 0.0
+        self._last_change_ts: float = 0.0
+
+    # ── public API ────────────────────────────────────────────────────────
+
+    @property
+    def mode(self) -> str:
+        """Currently effective mode (manual override wins, then auto)."""
+        return self._manual if self._manual is not None else self._auto_mode
+
+    @property
+    def source(self) -> str:
+        """How the current mode was decided — for logging / debugging."""
+        if self._manual is not None:
+            return "manual"
+        if self._auto_mode == MODE_UNKNOWN:
+            return "init"
+        return "auto"
+
+    def set_manual_mode(self, mode: Optional[str]) -> None:
+        """Set / clear manual override. Pass None to revert to auto detection."""
+        if mode is not None:
+            mode = mode.strip().lower()
+            if mode not in (MODE_INDOOR, MODE_OUTDOOR):
+                raise ValueError(f"Manual mode must be one of indoor/outdoor, got {mode!r}")
+        prev = self.mode
+        self._manual = mode
+        new = self.mode
+        if prev != new:
+            logger.info("SceneMode: manual %r → effective %s", mode, new)
+            self._last_change_ts = time.time()
+
+    def observe_gnss(self, fix_type: str, age_s: float, now: Optional[float] = None) -> bool:
+        """Feed a GNSS observation; returns True if the *auto* mode flipped.
+
+        ``fix_type`` should be the upper-case name (e.g. ``"RTK_FIXED"``).
+        Stale samples (age > gnss_max_age_s) and non-RTK fixes (when
+        require_rtk is on) are evidence for ``indoor``.
+        """
+        now = now if now is not None else time.time()
+        candidate: str
+        if age_s > self.config.gnss_max_age_s:
+            candidate = MODE_INDOOR
+        elif self.config.require_rtk and fix_type not in ("RTK_FIXED", "RTK_FLOAT"):
+            candidate = MODE_INDOOR
+        elif fix_type == "NO_FIX":
+            candidate = MODE_INDOOR
+        else:
+            candidate = MODE_OUTDOOR
+        return self._update_auto(candidate, now)
+
+    def observe_no_gnss(self, now: Optional[float] = None) -> bool:
+        """Tick when no GNSS message has arrived recently (also indoor evidence)."""
+        return self._update_auto(MODE_INDOOR, now if now is not None else time.time())
+
+    # ── internal ──────────────────────────────────────────────────────────
+
+    def _update_auto(self, candidate: str, now: float) -> bool:
+        if candidate == self._candidate_mode:
+            # Still building evidence for the same candidate.
+            elapsed = now - self._candidate_since_ts
+            if elapsed >= self.config.hold_seconds and self._auto_mode != candidate:
+                # Threshold met — flip auto mode.
+                old = self._auto_mode
+                self._auto_mode = candidate
+                self._last_change_ts = now
+                # Only log if it would change the *effective* mode.
+                if self._manual is None:
+                    logger.info(
+                        "SceneMode: auto %s → %s (consistent for %.1fs)",
+                        old, candidate, elapsed)
+                return True
+        else:
+            # Candidate flipped — restart the timer.
+            self._candidate_mode = candidate
+            self._candidate_since_ts = now
+        return False

--- a/src/gateway/gateway_module.py
+++ b/src/gateway/gateway_module.py
@@ -318,6 +318,7 @@ class GatewayModule(Module, layer=6):
     slope_grid:     In[dict]  # from TraversabilityCostModule — slope in degrees
     agent_message:  In[dict]  # from SemanticPlanner — chat-facing messages
     gnss_fusion_health: In[dict]  # from SlamBridgeModule — GNSS/SLAM alignment diag
+    localization_status: In[dict] # from SlamBridgeModule — full SLAM health (cov_trace, iter_num, ...)
     tare_stats:         In[dict]  # from TAREExplorerModule — exploration diag
     supervisor_state:   In[dict]  # from ExplorationSupervisorModule — watchdog
 
@@ -486,6 +487,8 @@ class GatewayModule(Module, layer=6):
         self.slope_grid.subscribe(self._on_slope_grid)
         self.agent_message.subscribe(self._on_agent_message)
         self.gnss_fusion_health.subscribe(self._on_gnss_fusion_health)
+        self.localization_status.subscribe(self._on_localization_status)
+        self.localization_status.set_policy("latest")
         self.tare_stats.subscribe(self._on_tare_stats)
         self.supervisor_state.subscribe(self._on_exploration_supervisor)
         self._app = self._build_app()
@@ -1248,6 +1251,17 @@ class GatewayModule(Module, layer=6):
         """Forward SlamBridge gnss_fusion_health to SSE (type=gnss_fusion)."""
         d = state if isinstance(state, dict) else {"raw": str(state)}
         self.push_event({"type": "gnss_fusion", "data": d})
+
+    def _on_localization_status(self, state: dict) -> None:
+        """Forward SlamBridge localization_status to SSE (type=slam_diag).
+
+        Surfaces IEKF internals (`pos_cov_trace`, `ieskf_iter_num`,
+        `ieskf_converged`) plus the existing degeneracy fields so dashboards
+        and the drift watchdog can react before pose itself blows up.
+        """
+        if not isinstance(state, dict):
+            return
+        self.push_event({"type": "slam_diag", "data": state})
 
     def _on_tare_stats(self, stats: dict) -> None:
         """Forward TAREExplorerModule tare_stats to SSE (type=tare_stats)."""

--- a/src/gateway/gateway_module.py
+++ b/src/gateway/gateway_module.py
@@ -441,6 +441,12 @@ class GatewayModule(Module, layer=6):
         self._drift_restart_count: int = 0
         self._drift_watchdog_thread: threading.Thread | None = None
 
+        # Crash-time black box. Records the gateway's view of the world (odom,
+        # slam_diag, gnss_fusion, map_odom_tf) and dumps to disk before the
+        # watchdog stops services, so we can attribute divergences offline.
+        from core.utils.blackbox_recorder import BlackBoxRecorder
+        self._blackbox = BlackBoxRecorder.from_env()
+
         # ── Session state machine (single source of truth) ─────────────────
         # Every mode transition must go through /api/v1/session/start|end.
         # Frontend Topbar/Panel render from this state; no other code path
@@ -587,6 +593,28 @@ class GatewayModule(Module, layer=6):
 
         # Snapshot session mode BEFORE stopping services
         mode = self._session_mode
+
+        # Black-box dump must happen BEFORE svc.stop, otherwise the
+        # localization_status / gnss / odom feeds dry up the moment slam exits
+        # and we lose the very tail-end of the divergence we want to study.
+        # Note: ``Path`` in this module imports the ROS message type, not
+        # pathlib.Path; the recorder returns a pathlib.Path so we leave this
+        # untyped to avoid the symbol clash.
+        dump_path = None
+        try:
+            dump_path = self._blackbox.dump(
+                reason="drift_watchdog",
+                metadata={
+                    "xy": float(xy),
+                    "y_abs": float(y_abs),
+                    "v": float(v),
+                    "session_mode": mode,
+                    "restart_count": self._drift_restart_count + 1,
+                },
+            )
+        except Exception as e:
+            logger.warning("drift_watchdog: blackbox dump failed (continuing): %s", e)
+
         try:
             svc.stop("slam", "slam_pgo", "localizer")
         except Exception as e:
@@ -598,14 +626,17 @@ class GatewayModule(Module, layer=6):
             self._odom = {}
             self._odom_timestamps.clear()
 
-        self.push_event({
+        evt: dict = {
             "type": "slam_drift",
             "level": "error",
             "xy": max(xy, y_abs),
             "v": v,
             "action": "slam_restart",
             "count": self._drift_restart_count + 1,
-        })
+        }
+        if dump_path is not None:
+            evt["dump_path"] = str(dump_path)
+        self.push_event(evt)
 
         # Re-ensure based on session mode. idle → don't restart anything.
         time.sleep(2.0)
@@ -792,6 +823,7 @@ class GatewayModule(Module, layer=6):
             self._odom_timestamps.append(time.time())
             if len(self._odom_timestamps) > 20:
                 self._odom_timestamps.pop(0)
+        self._blackbox.record("odom", d)
         self.push_event({"type": "odometry", "data": d})
 
         # Push slam_status at ~1Hz (every 10 odometry frames)
@@ -927,6 +959,7 @@ class GatewayModule(Module, layer=6):
         """
         if not tf or not tf.get("valid", False):
             return
+        self._blackbox.record("tf", tf)
         try:
             tx, ty, tz = float(tf["tx"]), float(tf["ty"]), float(tf["tz"])
             qx, qy, qz, qw = (float(tf["qx"]), float(tf["qy"]),
@@ -1250,6 +1283,7 @@ class GatewayModule(Module, layer=6):
     def _on_gnss_fusion_health(self, state: dict) -> None:
         """Forward SlamBridge gnss_fusion_health to SSE (type=gnss_fusion)."""
         d = state if isinstance(state, dict) else {"raw": str(state)}
+        self._blackbox.record("gnss", d)
         self.push_event({"type": "gnss_fusion", "data": d})
 
     def _on_localization_status(self, state: dict) -> None:
@@ -1261,6 +1295,7 @@ class GatewayModule(Module, layer=6):
         """
         if not isinstance(state, dict):
             return
+        self._blackbox.record("slam_diag", state)
         self.push_event({"type": "slam_diag", "data": state})
 
     def _on_tare_stats(self, stats: dict) -> None:

--- a/src/nav/navigation_module.py
+++ b/src/nav/navigation_module.py
@@ -85,6 +85,11 @@ class NavigationModule(Module, layer=5):
     teleop_active: In[bool]
     localization_status: In[dict]
     traversability: In[dict]  # W2-8: terrain class from TerrainModule
+    # P4: TF jump events from SlamBridgeModule. PGO loop closures and BBS3D
+    # relocalisations can move map→odom by metres in a single tick. Cached
+    # global path + waypoint then point at the wrong place. We force a replan
+    # on the next planning tick to catch up.
+    map_frame_jump_event: In[dict]
 
     # -- Outputs --
     waypoint:       Out[PoseStamped]
@@ -179,6 +184,7 @@ class NavigationModule(Module, layer=5):
         self.teleop_active.subscribe(self._on_teleop_active)
         self.localization_status.subscribe(self._on_localization_status)
         self.traversability.subscribe(self._on_traversability)
+        self.map_frame_jump_event.subscribe(self._on_map_frame_jump)
 
         if self._enable_ros2_bridge:
             try:
@@ -316,6 +322,28 @@ class NavigationModule(Module, layer=5):
         self._failure_reason = f"cancelled: {msg}" if msg else "cancelled"
         self._set_state(MissionState.CANCELLED)
         logger.info("Mission cancelled: %s", msg)
+
+    def _on_map_frame_jump(self, event: dict) -> None:
+        """SlamBridge detected a map↔odom TF discontinuity (P4).
+
+        The cached global path / waypoint were planned in the *old* map frame.
+        Force an immediate replan so we don't drive the robot toward a
+        coordinate that no longer matches reality. Costmap is in odom frame
+        so it remains valid; ESDF / OccupancyGrid handle their own clear via
+        their own subscription to this event.
+        """
+        if not isinstance(event, dict):
+            return
+        dt_m = event.get("dt_m", 0.0)
+        dyaw = event.get("dyaw_deg", 0.0)
+        # Only act if we have an active mission — idle robot doesn't care.
+        if self._state in (MissionState.EXECUTING, MissionState.PATROLLING) \
+                and self._goal is not None:
+            logger.warning(
+                "TF jump (Δt=%.2fm Δyaw=%.1f°) → forced replan",
+                dt_m, dyaw)
+            self._tracker.clear()  # invalidate current waypoint tracking
+            self._plan()
 
     def _on_localization_status(self, msg: dict) -> None:
         prev = self._loc_state

--- a/src/nav/navigation_module.py
+++ b/src/nav/navigation_module.py
@@ -342,25 +342,35 @@ class NavigationModule(Module, layer=5):
         self._apply_degeneracy_speed_limit()
 
     def _apply_degeneracy_speed_limit(self) -> None:
-        """Scale navigation speed based on SLAM degeneracy level.
+        """Scale navigation speed based on SLAM health.
 
-        NONE     → 1.0x (full speed)
-        MILD     → 0.7x (slight reduction)
-        SEVERE   → 0.4x (cautious)
-        CRITICAL → pause (handled by DEGRADED→LOST path above)
+        FALLBACK_GNSS_ONLY → 0.3x (cautious — SLAM has been DEGRADED for >10s
+                                   with healthy GNSS; we are essentially flying
+                                   on absolute fixes plus dead reckoning).
+        DEGEN SEVERE       → 0.4x
+        DEGEN MILD         → 0.7x
+        otherwise          → 1.0x
+
+        CRITICAL is handled by the DEGRADED→LOST path above (mission pauses).
         """
         prev_scale = self._speed_scale
-        if self._degen_level == "SEVERE":
+        reason = ""
+        if self._loc_state == "FALLBACK_GNSS_ONLY":
+            self._speed_scale = 0.3
+            reason = "FALLBACK_GNSS_ONLY"
+        elif self._degen_level == "SEVERE":
             self._speed_scale = 0.4
+            reason = "degeneracy=SEVERE"
         elif self._degen_level == "MILD":
             self._speed_scale = 0.7
+            reason = "degeneracy=MILD"
         else:
             self._speed_scale = 1.0
 
         if self._speed_scale != prev_scale and self._state == MissionState.EXECUTING:
             if self._speed_scale < 1.0:
-                logger.info("Navigation speed scaled to %.0f%% (degeneracy: %s)",
-                            self._speed_scale * 100, self._degen_level)
+                logger.info("Navigation speed scaled to %.0f%% (%s)",
+                            self._speed_scale * 100, reason)
             else:
                 logger.info("Navigation speed restored to 100%%")
 

--- a/src/slam/fastlio2/config/lio.yaml
+++ b/src/slam/fastlio2/config/lio.yaml
@@ -40,9 +40,11 @@ imu_init_num: 20
 near_search_num: 5
 ieskf_max_iter: 5
 
-# LiDAR↔IMU time offset (seconds). Aligns LiDAR clock to IMU clock by adding this
-# value to LiDAR message timestamps in the callback. Calibrated by LI-Init or similar;
-# applied automatically by `calibration/apply_calibration.py`. Plausible range: [-0.1, 0.1].
+# LiDAR↔IMU time offset (seconds). Positive value = IMU lags LiDAR by this much.
+# Applied IMU-side: t_imu_aligned = t_imu_raw - time_diff_lidar_to_imu, matching
+# upstream FAST-LIO / Point-LIO. Output odometry stamps therefore stay on the
+# LiDAR wall clock. Calibrated by LI-Init; written by `apply_calibration.py`.
+# Plausible range: [-0.1, 0.1].
 time_diff_lidar_to_imu: 0.0
 
 gravity_align: true

--- a/src/slam/fastlio2/config/lio.yaml
+++ b/src/slam/fastlio2/config/lio.yaml
@@ -40,6 +40,11 @@ imu_init_num: 20
 near_search_num: 5
 ieskf_max_iter: 5
 
+# LiDAR↔IMU time offset (seconds). Aligns LiDAR clock to IMU clock by adding this
+# value to LiDAR message timestamps in the callback. Calibrated by LI-Init or similar;
+# applied automatically by `calibration/apply_calibration.py`. Plausible range: [-0.1, 0.1].
+time_diff_lidar_to_imu: 0.0
+
 gravity_align: true
 esti_il: false
 

--- a/src/slam/fastlio2/src/lio_node.cpp
+++ b/src/slam/fastlio2/src/lio_node.cpp
@@ -414,11 +414,19 @@ public:
         ratio_msg.data = static_cast<float>(degen.effective_ratio);
         m_degen_pub->publish(ratio_msg);
 
-        // Publish detailed degeneracy info as Float32MultiArray
-        // [condition_number, min_eigenvalue, max_eigenvalue, effective_ratio,
-        //  degen_dof_count, mask_rx, mask_ry, mask_rz, mask_tx, mask_ty, mask_tz]
+        // Publish detailed degeneracy info as Float32MultiArray.
+        // Layout (older subscribers ignore extra trailing fields):
+        // [0]   condition_number
+        // [1]   min_eigenvalue
+        // [2]   max_eigenvalue
+        // [3]   effective_ratio
+        // [4]   degenerate_dof_count
+        // [5-10] dof_mask (rx,ry,rz,tx,ty,tz)
+        // [11]  pos_cov_trace (m²)             — IEKF position covariance trace
+        // [12]  iter_num                       — IEKF iterations actually used
+        // [13]  converged (1.0 if converged, 0.0 if hit max_iter)
         std_msgs::msg::Float32MultiArray detail_msg;
-        detail_msg.data.resize(11);
+        detail_msg.data.resize(14);
         detail_msg.data[0]  = static_cast<float>(degen.condition_number);
         detail_msg.data[1]  = static_cast<float>(degen.min_eigenvalue);
         detail_msg.data[2]  = static_cast<float>(degen.max_eigenvalue);
@@ -426,6 +434,9 @@ public:
         detail_msg.data[4]  = static_cast<float>(degen.degenerate_dof_count);
         for (int d = 0; d < 6; ++d)
             detail_msg.data[5 + d] = static_cast<float>(degen.dof_mask(d));
+        detail_msg.data[11] = static_cast<float>(degen.pos_cov_trace);
+        detail_msg.data[12] = static_cast<float>(degen.iter_num);
+        detail_msg.data[13] = degen.converged ? 1.0f : 0.0f;
         m_degen_detail_pub->publish(detail_msg);
 
         if (degen.detected)

--- a/src/slam/fastlio2/src/lio_node.cpp
+++ b/src/slam/fastlio2/src/lio_node.cpp
@@ -388,9 +388,12 @@ public:
     {
         if (!syncPackage())
             return;
+        if (m_first_sync_time == 0.0)
+            m_first_sync_time = m_package.cloud_end_time;
         auto t1 = std::chrono::high_resolution_clock::now();
         m_builder->process(m_package);
         auto t2 = std::chrono::high_resolution_clock::now();
+        warnIfStuck();
 
         if (m_node_config.print_time_cost)
         {
@@ -461,6 +464,44 @@ public:
         }
     }
 
+    // Surface two silent failure modes that S0.5 already exposes structurally
+    // (via /slam/degeneracy_detail) but that have no human-facing log:
+    //   - IEKF iteration loop hits m_max_iter without stop_func firing
+    //     → likely ill-conditioned Jacobian for the current observation set
+    //   - IMU init buffer never fills → wrong topic / dead driver / saturated IMU
+    // Throttled hard so a sustained issue does not drown the log.
+    void warnIfStuck()
+    {
+        // IEKF non-convergence — only meaningful once we are past initialisation.
+        if (m_builder->status() == BuilderStatus::MAPPING)
+        {
+            const auto &degen = m_kf->degeneracy();
+            if (!degen.converged)
+            {
+                RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 5000,
+                    "IEKF did not converge: iter_num=%d/%d, cond=%.2g — "
+                    "Jacobian likely ill-conditioned for current scan",
+                    degen.iter_num, m_builder_config.ieskf_max_iter,
+                    degen.condition_number);
+            }
+        }
+
+        // IMU init stuck — if we have synced packages but builder is still in
+        // IMU_INIT after a few seconds, something is wrong with the IMU stream.
+        if (m_builder->status() == BuilderStatus::IMU_INIT && m_first_sync_time > 0.0)
+        {
+            const double elapsed = m_package.cloud_end_time - m_first_sync_time;
+            if (elapsed > 5.0)
+            {
+                auto progress = m_builder->imu_processor()->initProgress();
+                RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 3000,
+                    "IMU init stuck for %.1fs: collected %d/%d samples — "
+                    "check /livox/imu topic, IMU sample rate, time_diff_lidar_to_imu",
+                    elapsed, progress.first, progress.second);
+            }
+        }
+    }
+
 private:
     rclcpp::Subscription<livox_ros_driver2::msg::CustomMsg>::SharedPtr m_lidar_sub;
     rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr m_pcl2_sub;
@@ -482,6 +523,10 @@ private:
     std::shared_ptr<MapBuilder> m_builder;
     std::shared_ptr<tf2_ros::TransformBroadcaster> m_tf_broadcaster;
     rclcpp::Service<interface::srv::SaveMaps>::SharedPtr m_save_map_srv;
+
+    // Wall-clock (LiDAR-clock) of the first successfully-synced package; used by
+    // warnIfStuck() to detect IMU init never completing.
+    double m_first_sync_time = 0.0;
 };
 
 int main(int argc, char **argv)

--- a/src/slam/fastlio2/src/lio_node.cpp
+++ b/src/slam/fastlio2/src/lio_node.cpp
@@ -36,6 +36,7 @@ struct NodeConfig
     int scan_line = 4;          // number of scan lines (4 for Mid-360, 16 for VLP-16)
     int timestamp_unit = NS;    // 0=SEC, 1=MS, 2=US, 3=NS
     double acc_scale = 10.0;    // IMU acceleration scale (10.0 for Livox g-units, 1.0 for standard m/s²)
+    double time_diff_lidar_to_imu = 0.0;  // seconds; added to LiDAR timestamps to align them with IMU clock (LI-Init output)
 };
 struct StateData
 {
@@ -160,6 +161,22 @@ public:
             m_builder_config.stationary_thresh = config["stationary_thresh"].as<double>();
         if (config["acc_scale"])
             m_node_config.acc_scale = config["acc_scale"].as<double>();
+        if (config["time_diff_lidar_to_imu"])
+        {
+            m_node_config.time_diff_lidar_to_imu = config["time_diff_lidar_to_imu"].as<double>();
+            if (std::abs(m_node_config.time_diff_lidar_to_imu) > 0.1)
+            {
+                RCLCPP_ERROR(this->get_logger(),
+                    "time_diff_lidar_to_imu = %.6f s exceeds plausible ±0.1s range — likely calibration error",
+                    m_node_config.time_diff_lidar_to_imu);
+            }
+            else if (m_node_config.time_diff_lidar_to_imu != 0.0)
+            {
+                RCLCPP_INFO(this->get_logger(),
+                    "Applying LiDAR→IMU time offset: %.6f s",
+                    m_node_config.time_diff_lidar_to_imu);
+            }
+        }
 
         // ZUPT parameters (optional, fall back to Config defaults)
         if (config["imu_static_acc_thresh"])
@@ -199,7 +216,7 @@ public:
     {
         CloudType::Ptr cloud = Utils::livox2PCL(msg, m_builder_config.lidar_filter_num, m_builder_config.lidar_min_range, m_builder_config.lidar_max_range);
         std::lock_guard<std::mutex> lock(m_state_data.lidar_mutex);
-        double timestamp = Utils::getSec(msg->header);
+        double timestamp = Utils::getSec(msg->header) + m_node_config.time_diff_lidar_to_imu;
         if (timestamp < m_state_data.last_lidar_time)
         {
             RCLCPP_WARN(this->get_logger(), "Lidar Message is out of order");
@@ -214,7 +231,7 @@ public:
                                                m_node_config.scan_line, m_node_config.timestamp_unit,
                                                m_builder_config.lidar_min_range, m_builder_config.lidar_max_range);
         std::lock_guard<std::mutex> lock(m_state_data.lidar_mutex);
-        double timestamp = Utils::getSec(msg->header);
+        double timestamp = Utils::getSec(msg->header) + m_node_config.time_diff_lidar_to_imu;
         if (timestamp < m_state_data.last_lidar_time)
         {
             RCLCPP_WARN(this->get_logger(), "Lidar Message is out of order");

--- a/src/slam/fastlio2/src/lio_node.cpp
+++ b/src/slam/fastlio2/src/lio_node.cpp
@@ -36,7 +36,11 @@ struct NodeConfig
     int scan_line = 4;          // number of scan lines (4 for Mid-360, 16 for VLP-16)
     int timestamp_unit = NS;    // 0=SEC, 1=MS, 2=US, 3=NS
     double acc_scale = 10.0;    // IMU acceleration scale (10.0 for Livox g-units, 1.0 for standard m/s²)
-    double time_diff_lidar_to_imu = 0.0;  // seconds; added to LiDAR timestamps to align them with IMU clock (LI-Init output)
+    // LI-Init output: positive value means IMU lags LiDAR by this many seconds.
+    // Applied IMU-side (subtracted from IMU stamps in imuCB) for parity with
+    // upstream FAST-LIO / Point-LIO so published odometry stamps stay on the
+    // LiDAR wall clock.
+    double time_diff_lidar_to_imu = 0.0;
 };
 struct StateData
 {
@@ -194,7 +198,14 @@ public:
     void imuCB(const sensor_msgs::msg::Imu::SharedPtr msg)
     {
         std::lock_guard<std::mutex> lock(m_state_data.imu_mutex);
-        double timestamp = Utils::getSec(msg->header);
+        // Upstream FAST-LIO / Point-LIO subtract `time_diff_lidar_to_imu` from
+        // the IMU stamp to align IMU clock onto the LiDAR timeline. We follow
+        // the same convention so the published odometry stamps live on the
+        // LiDAR wall clock (matches /cloud_registered stamps for TF lookups).
+        // Equivalent to LI-Init's documented "SUBTRACT this value from IMU
+        // timestamp OR ADD this value to LiDAR timestamp"; we pick the IMU
+        // side for parity with upstream.
+        double timestamp = Utils::getSec(msg->header) - m_node_config.time_diff_lidar_to_imu;
         if (timestamp < m_state_data.last_imu_time)
         {
             RCLCPP_WARN(this->get_logger(), "IMU Message is out of order");
@@ -216,7 +227,9 @@ public:
     {
         CloudType::Ptr cloud = Utils::livox2PCL(msg, m_builder_config.lidar_filter_num, m_builder_config.lidar_min_range, m_builder_config.lidar_max_range);
         std::lock_guard<std::mutex> lock(m_state_data.lidar_mutex);
-        double timestamp = Utils::getSec(msg->header) + m_node_config.time_diff_lidar_to_imu;
+        // LiDAR timestamps stay raw — the time_diff offset is applied on the
+        // IMU side in imuCB so output odom stamps remain on the LiDAR clock.
+        double timestamp = Utils::getSec(msg->header);
         if (timestamp < m_state_data.last_lidar_time)
         {
             RCLCPP_WARN(this->get_logger(), "Lidar Message is out of order");
@@ -231,7 +244,8 @@ public:
                                                m_node_config.scan_line, m_node_config.timestamp_unit,
                                                m_builder_config.lidar_min_range, m_builder_config.lidar_max_range);
         std::lock_guard<std::mutex> lock(m_state_data.lidar_mutex);
-        double timestamp = Utils::getSec(msg->header) + m_node_config.time_diff_lidar_to_imu;
+        // See lidarCB — offset is applied IMU-side, not here.
+        double timestamp = Utils::getSec(msg->header);
         if (timestamp < m_state_data.last_lidar_time)
         {
             RCLCPP_WARN(this->get_logger(), "Lidar Message is out of order");

--- a/src/slam/fastlio2/src/map_builder/ieskf.cpp
+++ b/src/slam/fastlio2/src/map_builder/ieskf.cpp
@@ -247,6 +247,10 @@ void IESKF::update()
 
     // Store degeneracy info for external access (ROS2 publisher)
     m_degeneracy = shared_data.degeneracy;
+    m_degeneracy.iter_num = static_cast<int>(shared_data.iter_num);
+    // Loop exited via m_stop_func only if iter_num < m_max_iter; equality means
+    // we ran the max iterations without convergence — flag for diagnostics.
+    m_degeneracy.converged = (shared_data.iter_num < m_max_iter);
 
     // Pathological degeneracy: revert to IMU prediction entirely (eigenbasis
     // is numerically unreliable so OC projection cannot be trusted either).
@@ -254,6 +258,7 @@ void IESKF::update()
     {
         m_x = predict_x;
         clampCovariance();
+        m_degeneracy.pos_cov_trace = m_P.diagonal().segment<3>(3).sum();
         return;
     }
 
@@ -285,4 +290,5 @@ void IESKF::update()
     }
 
     clampCovariance();
+    m_degeneracy.pos_cov_trace = m_P.diagonal().segment<3>(3).sum();
 }

--- a/src/slam/fastlio2/src/map_builder/ieskf.h
+++ b/src/slam/fastlio2/src/map_builder/ieskf.h
@@ -26,6 +26,14 @@ struct DegeneracyInfo
     Eigen::Matrix<double, 6, 1> eigenvalues = Eigen::Matrix<double, 6, 1>::Zero();
     // Per-DOF degeneracy mask: 1.0 = well-constrained, 0.0 = degenerate
     Eigen::Matrix<double, 6, 1> dof_mask = Eigen::Matrix<double, 6, 1>::Ones();
+    // Position covariance trace (m²) — sum of t_wi diagonals after the update.
+    // Surfacing this lets external monitors detect IEKF divergence ~30-60s before
+    // pose itself blows up, which is when watchdog finally trips on |xy|.
+    double pos_cov_trace = 0.0;
+    // Iterations actually used in the last update. iter_num == m_max_iter without
+    // converging suggests the Jacobian is ill-conditioned for current observations.
+    int iter_num = 0;
+    bool converged = true;           // false if loop exited at m_max_iter without stop_func
 };
 
 struct SharedState

--- a/src/slam/fastlio2/src/map_builder/imu_processor.h
+++ b/src/slam/fastlio2/src/map_builder/imu_processor.h
@@ -11,6 +11,13 @@ public:
 
     void undistort(SyncPackage &package);
 
+    // Progress of IMU initialisation as (samples_collected, samples_required).
+    // Used by lio_node.cpp to log a stuck-init warning when the cache fills
+    // too slowly (no IMU stream, wrong topic, or driver crashed).
+    std::pair<int, int> initProgress() const {
+        return {static_cast<int>(m_imu_cache.size()), m_config.imu_init_num};
+    }
+
 private:
     void checkIMUStationary(const Vec<IMUData> &batch);
 

--- a/src/slam/fastlio2/src/map_builder/map_builder.h
+++ b/src/slam/fastlio2/src/map_builder/map_builder.h
@@ -15,8 +15,9 @@ public:
     MapBuilder(Config &config, std::shared_ptr<IESKF> kf);
 
     void process(SyncPackage &package);
-    BuilderStatus status() { return m_status; }    
+    BuilderStatus status() { return m_status; }
     std::shared_ptr<LidarProcessor> lidar_processor(){return m_lidar_processor;}
+    std::shared_ptr<IMUProcessor> imu_processor(){return m_imu_processor;}
     void saveMap(const std::string &path);
 
 private:

--- a/src/slam/localizer/CMakeLists.txt
+++ b/src/slam/localizer/CMakeLists.txt
@@ -28,7 +28,27 @@ find_package(std_srvs REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(PCL REQUIRED)
 find_package(yaml-cpp REQUIRED)
+find_package(OpenMP REQUIRED)
 
+# small_gicp (Koide 2024, MIT) — replaces pcl::IterativeClosestPoint in
+# icp_localizer to expose the registration Hessian, iteration count, and
+# converged flag. PCL's ICP wrapper exposed only fitness, which forced P3
+# multi-frame health gating to single-axis (fitness only). small_gicp is
+# header-only friendly via FetchContent and ships a drop-in PCL-style
+# RegistrationPCL adapter so the call sites change minimally.
+#
+# We prefer find_package first (system install path on S100P) and fall
+# back to FetchContent when absent so CI / fresh dev machines work.
+find_package(small_gicp QUIET)
+if(NOT small_gicp_FOUND)
+  message(STATUS "small_gicp not installed — fetching v1.0.0")
+  include(FetchContent)
+  FetchContent_Declare(small_gicp
+    GIT_REPOSITORY https://github.com/koide3/small_gicp.git
+    GIT_TAG v1.0.0
+  )
+  FetchContent_MakeAvailable(small_gicp)
+endif()
 
 
 include_directories(
@@ -44,7 +64,7 @@ set(SRC_LIST src/localizers/commons.cpp
 
 add_executable(localizer_node src/localizer_node.cpp ${SRC_LIST})
 ament_target_dependencies(localizer_node rclcpp std_msgs sensor_msgs nav_msgs message_filters pcl_conversions tf2_ros geometry_msgs interface std_srvs)
-target_link_libraries(localizer_node ${PCL_LIBRARIES}  yaml-cpp /usr/local/lib/libcpu_bbs3d.so)
+target_link_libraries(localizer_node ${PCL_LIBRARIES} yaml-cpp /usr/local/lib/libcpu_bbs3d.so small_gicp::small_gicp OpenMP::OpenMP_CXX)
 
 
 install(TARGETS localizer_node DESTINATION lib/${PROJECT_NAME})

--- a/src/slam/localizer/src/localizer_node.cpp
+++ b/src/slam/localizer/src/localizer_node.cpp
@@ -18,6 +18,7 @@
 #include <tf2_ros/transform_broadcaster.h>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <std_msgs/msg/float32.hpp>
+#include <std_msgs/msg/string.hpp>
 
 #include "localizers/commons.h"
 #include "localizers/icp_localizer.h"
@@ -95,6 +96,10 @@ public:
 
         m_map_cloud_pub = this->create_publisher<sensor_msgs::msg::PointCloud2>("map_cloud", 10);
         m_quality_pub = this->create_publisher<std_msgs::msg::Float32>("/localization_quality", 10);
+        // Externalised lost/lock health for SlamBridge → Gateway consumption.
+        // Multi-frame confirmation gate (see updateAndPublishHealth) prevents
+        // single-frame ICP hiccups from spuriously alarming Navigation.
+        m_health_pub = this->create_publisher<std_msgs::msg::String>("/nav/localization_health", 10);
 
         m_timer = this->create_wall_timer(10ms, std::bind(&LocalizerNode::timerCB, this));
 
@@ -356,8 +361,52 @@ public:
             m_quality_pub->publish(quality_msg);
         }
 
+        // Externalised LOCKED/LOST health (multi-frame confirmed)
+        updateAndPublishHealth(result, fitness);
+
         sendBroadCastTF(current_time);
         publishMapCloud(current_time);
+    }
+
+    // HDL-Localization style multi-frame health gate. The internal
+    // m_state.localize_success can flip per frame; this layer only flips
+    // the externally-published health after N consecutive same-direction
+    // frames so navigation does not see ICP single-frame jitter.
+    void updateAndPublishHealth(bool result, float fitness)
+    {
+        if (result)
+        {
+            m_consec_locked++;
+            m_consec_lost = 0;
+        }
+        else
+        {
+            m_consec_lost++;
+            m_consec_locked = 0;
+        }
+
+        std::string desired = m_published_health;
+        if (m_consec_lost >= LOST_CONFIRM_FRAMES)
+            desired = "LOST";
+        else if (m_consec_locked >= RECOVER_CONFIRM_FRAMES && m_published_health != "UNKNOWN")
+            desired = "RECOVERED";
+        else if (m_consec_locked >= RECOVER_CONFIRM_FRAMES && m_published_health == "UNKNOWN")
+            desired = "LOCKED";
+
+        if (desired != m_published_health)
+        {
+            std_msgs::msg::String msg;
+            // payload format: "<state>|fitness=<value>" — keeps subscribers
+            // (SlamBridgeModule) able to parse with str.split('|').
+            msg.data = desired + "|fitness=" + std::to_string(fitness);
+            m_health_pub->publish(msg);
+            RCLCPP_INFO(this->get_logger(),
+                "Localization health → %s (fitness=%.4f)", desired.c_str(), fitness);
+            m_published_health = desired;
+            // After a RECOVERED transition the next steady state is LOCKED; do
+            // not re-publish each frame, just collapse on next state change.
+            if (desired == "RECOVERED") m_published_health = "LOCKED";
+        }
     }
     void syncCB(const sensor_msgs::msg::PointCloud2::ConstSharedPtr &cloud_msg, const nav_msgs::msg::Odometry::ConstSharedPtr &odom_msg)
     {
@@ -586,6 +635,18 @@ private:
     rclcpp::Service<interface::srv::IsValid>::SharedPtr m_reloc_check_srv;
     rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr m_map_cloud_pub;
     rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr m_quality_pub;
+    rclcpp::Publisher<std_msgs::msg::String>::SharedPtr m_health_pub;
+
+    // Multi-frame confirmation state for /nav/localization_health.
+    // HDL-Localization pattern: a single bad ICP frame is not enough to
+    // declare LOST; require N consecutive bad frames first, and likewise N
+    // consecutive good frames before re-declaring RECOVERED. Otherwise a
+    // momentary scan match dip would flap the public health state.
+    int m_consec_lost   = 0;
+    int m_consec_locked = 0;
+    std::string m_published_health = "UNKNOWN";  // last value sent on m_health_pub
+    static constexpr int LOST_CONFIRM_FRAMES = 5;
+    static constexpr int RECOVER_CONFIRM_FRAMES = 3;
 };
 int main(int argc, char **argv)
 {

--- a/src/slam/localizer/src/localizer_node.cpp
+++ b/src/slam/localizer/src/localizer_node.cpp
@@ -1,6 +1,7 @@
 #include <atomic>
 #include <chrono>
 #include <cmath>
+#include <cstdio>      // std::snprintf in launchAutoBBS3D reason builder
 #include <fstream>
 #include <filesystem>
 #include <iomanip>
@@ -303,41 +304,24 @@ public:
         }
 
         // ── (C) Drift watchdog: N consecutive bad frames → auto BBS3D ─
+        // Fast-reaction path: looks at raw fitness streak per frame.
+        // Independent from the multi-frame health gate (P3) which fires
+        // BBS3D from updateAndPublishHealth() on a slower, more
+        // conservative LOST decision. Both call launchAutoBBS3D() so the
+        // 60s cooldown + m_bbs3d_running mutex are shared.
         if (result && fitness > m_drift_bad_thresh) {
             m_drift_bad_count++;
         } else {
             m_drift_bad_count = 0;
         }
-        auto _now_dw = std::chrono::steady_clock::now();
-        auto _since_reloc = std::chrono::duration_cast<std::chrono::seconds>(
-            _now_dw - m_last_auto_reloc).count();
-        if (m_drift_bad_count >= m_drift_trigger_frames
-            && _since_reloc >= 60
-            && !m_bbs3d_running.exchange(true)) {
-            m_drift_bad_count = 0;
-            m_last_auto_reloc = _now_dw;
-            RCLCPP_WARN(this->get_logger(),
-                "Drift watchdog: fitness >%.2f for %d frames → auto BBS3D",
+        if (m_drift_bad_count >= m_drift_trigger_frames) {
+            char reason[96];
+            std::snprintf(reason, sizeof(reason),
+                "drift_streak fitness>%.2f for %d frames",
                 m_drift_bad_thresh, m_drift_trigger_frames);
-            CloudType::Ptr scan_copy(new CloudType);
-            { std::lock_guard<std::mutex> lk(m_state.message_mutex);
-              *scan_copy = *m_state.last_cloud; }
-            std::thread([this, scan_copy]() {
-                auto r = m_bbs3d->localize(scan_copy);
-                if (r.success) {
-                    std::lock_guard<std::mutex> svc(m_state.service_mutex);
-                    m_state.initial_guess = r.pose;
-                    m_state.service_received = true;
-                    m_state.localize_success = false;
-                    RCLCPP_INFO(this->get_logger(),
-                        "Drift recovery OK: t=[%.2f,%.2f,%.2f]",
-                        r.pose(0,3), r.pose(1,3), r.pose(2,3));
-                } else {
-                    RCLCPP_WARN(this->get_logger(),
-                        "Drift recovery failed: %s", r.message.c_str());
-                }
-                m_bbs3d_running = false;
-            }).detach();
+            if (launchAutoBBS3D(reason)) {
+                m_drift_bad_count = 0;
+            }
         }
 
         if (result)
@@ -414,11 +398,79 @@ public:
             RCLCPP_INFO(this->get_logger(),
                 "Localization health → %s (fitness=%.4f iter=%d cov=%.4f)",
                 desired.c_str(), fitness, iter, cov);
+
+            // P7a: on a fresh LOST transition, kick BBS3D for global
+            // re-localization. Without this, the multi-frame health
+            // gate would only *publish* LOST (so navigation slows /
+            // stops) but never *recover* — the recovery path was tied
+            // exclusively to the (C) drift watchdog's raw-fitness
+            // streak. Now LOST triggers recovery via the same shared
+            // helper (60s cooldown + atomic mutex prevent double-fire).
+            // We deliberately do not block the publish itself on the
+            // BBS3D launch — Navigation must see LOST before recovery
+            // begins so it can stop / hold position.
+            if (desired == "LOST" && m_published_health != "LOST") {
+                launchAutoBBS3D("multi-frame LOST (P3 health gate)");
+            }
+
             m_published_health = desired;
             // After a RECOVERED transition the next steady state is LOCKED; do
             // not re-publish each frame, just collapse on next state change.
             if (desired == "RECOVERED") m_published_health = "LOCKED";
         }
+    }
+
+    // P7a: shared launch path for auto BBS3D recovery. Returns true if
+    // this call actually started a BBS3D worker thread, false if the
+    // call was throttled (cooldown still active, BBS3D already running,
+    // map not loaded, or no scan received yet). Caller should NOT
+    // assume recovery happens — it is best-effort. Inputs:
+    //   reason — short tag included in logs to attribute which
+    //            trigger fired (drift_streak vs multi-frame LOST etc).
+    //
+    // The 60-second cooldown is the same value the (C) drift watchdog
+    // had: long enough that BBS3D (1-3 s on CPU) cannot self-trigger,
+    // short enough that a genuinely lost robot recovers within ~1 min.
+    bool launchAutoBBS3D(const std::string& reason)
+    {
+        auto _now = std::chrono::steady_clock::now();
+        auto _since = std::chrono::duration_cast<std::chrono::seconds>(
+            _now - m_last_auto_reloc).count();
+        if (_since < 60) return false;
+        if (!m_bbs3d || !m_bbs3d->has_map()) return false;
+        if (!m_state.message_received) return false;
+        if (m_bbs3d_running.exchange(true)) return false;
+
+        m_last_auto_reloc = _now;
+        RCLCPP_WARN(this->get_logger(),
+            "Auto BBS3D triggered: %s", reason.c_str());
+
+        CloudType::Ptr scan_copy(new CloudType);
+        { std::lock_guard<std::mutex> lk(m_state.message_mutex);
+          *scan_copy = *m_state.last_cloud; }
+        std::thread([this, scan_copy, reason]() {
+            auto r = m_bbs3d->localize(scan_copy);
+            if (r.success) {
+                std::lock_guard<std::mutex> svc(m_state.service_mutex);
+                m_state.initial_guess = r.pose;
+                m_state.service_received = true;
+                m_state.localize_success = false;
+                RCLCPP_INFO(this->get_logger(),
+                    "Auto-recovery OK (%s): t=[%.2f,%.2f,%.2f]",
+                    reason.c_str(), r.pose(0,3), r.pose(1,3), r.pose(2,3));
+                // Reset the LOST counter so the next LOCKED frame can
+                // promote to RECOVERED quickly. Without this reset the
+                // health gate would still see m_consec_lost ≥
+                // LOST_CONFIRM_FRAMES until enough good frames pass.
+                m_consec_lost = 0;
+            } else {
+                RCLCPP_WARN(this->get_logger(),
+                    "Auto-recovery failed (%s): %s",
+                    reason.c_str(), r.message.c_str());
+            }
+            m_bbs3d_running = false;
+        }).detach();
+        return true;
     }
     void syncCB(const sensor_msgs::msg::PointCloud2::ConstSharedPtr &cloud_msg, const nav_msgs::msg::Odometry::ConstSharedPtr &odom_msg)
     {
@@ -654,8 +706,14 @@ private:
     // declare LOST; require N consecutive bad frames first, and likewise N
     // consecutive good frames before re-declaring RECOVERED. Otherwise a
     // momentary scan match dip would flap the public health state.
-    int m_consec_lost   = 0;
-    int m_consec_locked = 0;
+    // P7a: m_consec_lost can now be reset from the BBS3D worker thread
+    // (in launchAutoBBS3D's lambda on success), in addition to the
+    // per-frame increment/reset on the timer thread. Atomic prevents
+    // torn reads on the comparison `m_consec_lost >= LOST_CONFIRM_FRAMES`
+    // while the worker is mid-write. m_consec_locked is timer-only but
+    // declared atomic for symmetry — relaxed semantics are sufficient.
+    std::atomic<int> m_consec_lost{0};
+    std::atomic<int> m_consec_locked{0};
     std::string m_published_health = "UNKNOWN";  // last value sent on m_health_pub
     static constexpr int LOST_CONFIRM_FRAMES = 5;
     static constexpr int RECOVER_CONFIRM_FRAMES = 3;

--- a/src/slam/localizer/src/localizer_node.cpp
+++ b/src/slam/localizer/src/localizer_node.cpp
@@ -396,12 +396,24 @@ public:
         if (desired != m_published_health)
         {
             std_msgs::msg::String msg;
-            // payload format: "<state>|fitness=<value>" — keeps subscribers
-            // (SlamBridgeModule) able to parse with str.split('|').
-            msg.data = desired + "|fitness=" + std::to_string(fitness);
+            // R4: extended payload format
+            //   "<state>|fitness=<v>|iter=<n>|cov=<v>"
+            // Keys are pipe-separated and order-insensitive on the
+            // subscriber side. Adding fields is backward-compatible —
+            // older parsers ignore unknown keys after the first '|'.
+            // iter and cov come from small_gicp's RegistrationResult /
+            // Hessian respectively, replacing the single-axis fitness
+            // gate the original P3 commit was forced to settle for.
+            const int  iter = m_localizer->getLastIterations();
+            const double cov = m_localizer->getLastPosCovTrace();
+            msg.data = desired
+                     + "|fitness=" + std::to_string(fitness)
+                     + "|iter="    + std::to_string(iter)
+                     + "|cov="     + std::to_string(cov);
             m_health_pub->publish(msg);
             RCLCPP_INFO(this->get_logger(),
-                "Localization health → %s (fitness=%.4f)", desired.c_str(), fitness);
+                "Localization health → %s (fitness=%.4f iter=%d cov=%.4f)",
+                desired.c_str(), fitness, iter, cov);
             m_published_health = desired;
             // After a RECOVERED transition the next steady state is LOCKED; do
             // not re-publish each frame, just collapse on next state change.

--- a/src/slam/localizer/src/localizers/icp_localizer.cpp
+++ b/src/slam/localizer/src/localizers/icp_localizer.cpp
@@ -6,6 +6,15 @@ ICPLocalizer::ICPLocalizer(const ICPConfig &config) : m_config(config)
     m_refine_tgt.reset(new CloudType);
     m_rough_inp.reset(new CloudType);
     m_rough_tgt.reset(new CloudType);
+
+    // small_gicp registration tuning. We default to plain ICP to preserve
+    // the previous behaviour bit-for-bit; switching to GICP requires
+    // re-tuning refine_score_thresh because the fitness metric changes
+    // (point-to-plane vs point-to-point).
+    m_rough_icp.setNumThreads(m_config.num_threads);
+    m_rough_icp.setRegistrationType("ICP");
+    m_refine_icp.setNumThreads(m_config.num_threads);
+    m_refine_icp.setRegistrationType("ICP");
 }
 bool ICPLocalizer::loadMap(const std::string &path)
 {
@@ -77,21 +86,53 @@ bool ICPLocalizer::align(M4F &guess)
 {
     CloudType::Ptr aligned_cloud(new CloudType);
     if (m_refine_tgt->size() == 0 || m_rough_tgt->size() == 0) {
-        m_last_fitness_score = -1.0f;
+        m_last_fitness_score = -1.0;
+        m_last_iterations = -1;
+        m_last_converged = false;
+        m_last_pos_cov_trace = -1.0;
         return false;
     }
-    // setInputTarget + setMaximumIterations 已在 loadMap() 中完成 (KD-tree 已缓存)
+    // setInputTarget + setMaximumIterations were done in loadMap()
+    // (KD-tree already cached).
     m_rough_icp.setInputSource(m_rough_inp);
     m_rough_icp.align(*aligned_cloud, guess);
     if (!m_rough_icp.hasConverged() ||
         m_rough_icp.getFitnessScore() > m_config.rough_score_thresh) {
-        m_last_fitness_score = static_cast<float>(m_rough_icp.getFitnessScore());
+        m_last_fitness_score = m_rough_icp.getFitnessScore();
+        m_last_iterations = m_rough_icp.getRegistrationResult().iterations;
+        m_last_converged = false;
+        m_last_pos_cov_trace = -1.0;
         return false;
     }
     m_refine_icp.setInputSource(m_refine_inp);
     m_refine_icp.align(*aligned_cloud, m_rough_icp.getFinalTransformation());
     m_last_fitness_score = m_refine_icp.getFitnessScore();
-    if (!m_refine_icp.hasConverged() || m_last_fitness_score > m_config.refine_score_thresh)
+
+    // R4: capture full diagnostics from small_gicp's refine result.
+    // Position covariance is the top-left 3x3 of H^-1; we surface its
+    // trace because the localizer's downstream consumer (P3) reduces
+    // to a scalar health value anyway. Inverting only the 3x3 block
+    // (instead of the full 6x6 H) is both cheap and well-conditioned —
+    // the rotation block can be near-singular under planar scenes and
+    // would otherwise blow up the trace numerically.
+    const auto &refine_result = m_refine_icp.getRegistrationResult();
+    m_last_iterations = refine_result.iterations;
+    m_last_converged = refine_result.converged;
+    {
+        const Eigen::Matrix<double, 6, 6> H = m_refine_icp.getFinalHessian();
+        const Eigen::Matrix3d H_pos = H.block<3, 3>(0, 0);
+        // Guard against singular H_pos (planar / degenerate observation).
+        const Eigen::JacobiSVD<Eigen::Matrix3d> svd(H_pos);
+        const double cond = svd.singularValues()(0)
+                            / std::max(svd.singularValues()(2), 1e-12);
+        if (cond > 1e8 || svd.singularValues()(2) < 1e-9) {
+            m_last_pos_cov_trace = -1.0;  // sentinel: ill-conditioned
+        } else {
+            m_last_pos_cov_trace = H_pos.inverse().trace();
+        }
+    }
+
+    if (!m_last_converged || m_last_fitness_score > m_config.refine_score_thresh)
         return false;
     guess = m_refine_icp.getFinalTransformation();
     return true;

--- a/src/slam/localizer/src/localizers/icp_localizer.h
+++ b/src/slam/localizer/src/localizers/icp_localizer.h
@@ -2,8 +2,8 @@
 #include "commons.h"
 #include <filesystem>
 #include <pcl/io/pcd_io.h>
-#include <pcl/registration/icp.h>
 #include <pcl/filters/voxel_grid.h>
+#include <small_gicp/pcl/pcl_registration.hpp>
 
 struct ICPConfig
 {
@@ -16,15 +16,21 @@ struct ICPConfig
     double rough_map_resolution = 0.25;
     double rough_score_thresh = 0.2;
     int rough_max_iteration = 5;
+
+    // Number of OpenMP threads for small_gicp parallel reduction. Set 0
+    // (default) to let the implementation pick something reasonable; set
+    // explicitly when running alongside SLAM/PGO that already saturate
+    // the CPU and we want to bound the localizer's footprint.
+    int num_threads = 4;
 };
 
 class ICPLocalizer
 {
 public:
     ICPLocalizer(const ICPConfig &config);
-    
+
     bool loadMap(const std::string &path);
-    
+
     void setInput(const CloudType::Ptr &cloud);
 
     bool align(M4F &guess);
@@ -35,15 +41,36 @@ public:
     /// Last ICP fitness score (lower = better alignment, 0 = perfect)
     double getLastFitnessScore() const { return m_last_fitness_score; }
 
+    /// R4: three-axis health diagnostics from small_gicp. Together with
+    /// fitness these give the multi-frame health gate (P3) the iter +
+    /// covariance signals it was missing under PCL ICP. All values come
+    /// from the *refine* stage's RegistrationResult — rough is a coarse
+    /// pre-step whose iteration count is uninformative.
+    int    getLastIterations()  const { return m_last_iterations; }
+    bool   getLastConverged()   const { return m_last_converged; }
+
+    /// Trace of the position covariance estimated from the registration
+    /// Hessian (top-left 3x3 block of H^-1). Larger = more uncertain
+    /// translation. Returns -1 when no align() has succeeded yet.
+    double getLastPosCovTrace() const { return m_last_pos_cov_trace; }
+
 private:
     ICPConfig m_config;
     pcl::VoxelGrid<PointType> m_voxel_filter;
-    pcl::IterativeClosestPoint<PointType, PointType> m_refine_icp;
-    pcl::IterativeClosestPoint<PointType, PointType> m_rough_icp;
+    // Drop-in replacement for pcl::IterativeClosestPoint. small_gicp's
+    // RegistrationPCL inherits from pcl::Registration so the call sites
+    // (setInputSource/Target, align) are unchanged. The win is the
+    // post-align getters: getFinalHessian() + getRegistrationResult()
+    // expose the diagnostics PCL ICP swallowed.
+    small_gicp::RegistrationPCL<PointType, PointType> m_refine_icp;
+    small_gicp::RegistrationPCL<PointType, PointType> m_rough_icp;
     CloudType::Ptr m_refine_inp;
     CloudType::Ptr m_rough_inp;
     CloudType::Ptr m_refine_tgt;
     CloudType::Ptr m_rough_tgt;
     std::string m_pcd_path;
-    double m_last_fitness_score{-1.0};  // -1 = not yet computed
+    double m_last_fitness_score{-1.0};   // -1 = not yet computed
+    int    m_last_iterations{-1};
+    bool   m_last_converged{false};
+    double m_last_pos_cov_trace{-1.0};   // -1 = not yet computed
 };

--- a/src/slam/pgo/config/pgo.yaml
+++ b/src/slam/pgo/config/pgo.yaml
@@ -18,6 +18,11 @@ min_loop_detect_duration: 5.0
 
 # Scan Context (Kim & Kim 2018) loop pre-filter — primary indoor anchor for
 # global drift correction when GNSS is unavailable. See pgos/scan_context.h.
+#
+# ⚠️ Pending replacement with MapClosures (MIT, ICRA 2024) — see the
+# DEPRECATED notice at the top of pgos/scan_context.h and the migration
+# RFC in docs/REVIEW_2026Q2.md. Until that lands, leave this enabled
+# for indoor / mixed deployments.
 enable_scan_context: true
 sc_distance_threshold: 0.4    # cosine-based descriptor distance gate
 sc_max_range: 20.0            # m — points beyond this are clipped from descriptor

--- a/src/slam/pgo/config/pgo.yaml
+++ b/src/slam/pgo/config/pgo.yaml
@@ -5,9 +5,21 @@ local_frame: odom
 
 key_pose_delta_deg: 10
 key_pose_delta_trans: 0.5
-loop_search_radius: 1.0
+
+# Loop search radius: with Scan Context enabled this is a sanity check (SC
+# proposes the candidate, we reject if it's spatially absurd). Was 1.0 before
+# Scan Context — too small to catch revisits across rooms.
+loop_search_radius: 15.0
 loop_time_tresh: 60.0
 loop_score_tresh: 0.15
 loop_submap_half_range: 5
 submap_resolution: 0.1
 min_loop_detect_duration: 5.0
+
+# Scan Context (Kim & Kim 2018) loop pre-filter — primary indoor anchor for
+# global drift correction when GNSS is unavailable. See pgos/scan_context.h.
+enable_scan_context: true
+sc_distance_threshold: 0.4    # cosine-based descriptor distance gate
+sc_max_range: 20.0            # m — points beyond this are clipped from descriptor
+sc_num_candidates: 5          # top-K KdTree candidates verified with full SC
+sc_min_history_gap: 30        # min #keyframes between query and candidate

--- a/src/slam/pgo/src/pgo_node.cpp
+++ b/src/slam/pgo/src/pgo_node.cpp
@@ -81,6 +81,18 @@ public:
         m_pgo_config.loop_submap_half_range = config["loop_submap_half_range"].as<int>();
         m_pgo_config.submap_resolution = config["submap_resolution"].as<double>();
         m_pgo_config.min_loop_detect_duration = config["min_loop_detect_duration"].as<double>();
+
+        // Scan Context (optional, defaults from Config{} if missing in YAML).
+        if (config["enable_scan_context"])
+            m_pgo_config.enable_scan_context = config["enable_scan_context"].as<bool>();
+        if (config["sc_distance_threshold"])
+            m_pgo_config.sc_distance_threshold = config["sc_distance_threshold"].as<double>();
+        if (config["sc_max_range"])
+            m_pgo_config.sc_max_range = config["sc_max_range"].as<double>();
+        if (config["sc_num_candidates"])
+            m_pgo_config.sc_num_candidates = config["sc_num_candidates"].as<int>();
+        if (config["sc_min_history_gap"])
+            m_pgo_config.sc_min_history_gap = config["sc_min_history_gap"].as<int>();
     }
     void syncCB(const sensor_msgs::msg::PointCloud2::ConstSharedPtr &cloud_msg, const nav_msgs::msg::Odometry::ConstSharedPtr &odom_msg)
     {

--- a/src/slam/pgo/src/pgos/scan_context.h
+++ b/src/slam/pgo/src/pgos/scan_context.h
@@ -1,5 +1,40 @@
 #pragma once
 //
+// ⚠️  DEPRECATED — pending replacement with PRBonn/MapClosures (MIT).
+//
+// This file was written in commit 850b75d as a stop-gap when N1 first
+// landed. The team review (R3 audit, post-Sprint 1) flagged two issues:
+//
+//   1. **Hand-written algorithm.** The audit's standing rule is "use
+//      mature upstream libraries, do not re-implement loop closure
+//      math." The 250-line implementation here is correct vs the Kim
+//      2018 paper but has zero real-data validation.
+//
+//   2. **License of the obvious upstream port** (aserbremen/scancontext_ros2)
+//      turned out to be **CC-BY-NC-SA 4.0** — non-commercial, unusable
+//      for LingTu. So a like-for-like upstream swap is not available.
+//
+// **Replacement target: PRBonn/MapClosures (MIT, ICRA 2024).**
+//   - License: MIT (https://github.com/PRBonn/MapClosures/blob/main/LICENSE)
+//   - Active maintenance (commit within last month at time of writing)
+//   - Algorithm: BEV occupancy projection + ORB descriptors. The audit
+//     argues this is *better* than Scan Context for sparse 4-line LiDAR
+//     (Mid-360) because BEV occupancy is robust to ring count, whereas
+//     ring-sector descriptors degrade as you drop scan lines.
+//
+// Migration plan tracked in docs/REVIEW_2026Q2.md. Rough scope (~2-3
+// weeks, separate sprint):
+//   - Add MapClosures via FetchContent in src/slam/pgo/CMakeLists.txt
+//   - New wrapper map_closures_loop_detector.h exposing add(cloud) +
+//     query(idx) -> {idx, yaw} matching the call sites in simple_pgo.cpp
+//   - Delete this file
+//   - pgo.yaml: enable_scan_context → loop_detector: scan_context|map_closures
+//
+// Until that migration lands, this file is the production loop detector
+// for indoor scenarios. Do NOT edit the algorithm here — any tuning
+// should go into the MapClosures wrapper instead.
+//
+// ──────────────────────────────────────────────────────────────────────
 // scan_context.h — minimal Scan Context (Kim & Kim, IROS 2018) descriptor
 // vendored for indoor loop closure pre-filtering.
 //

--- a/src/slam/pgo/src/pgos/scan_context.h
+++ b/src/slam/pgo/src/pgos/scan_context.h
@@ -1,0 +1,225 @@
+#pragma once
+//
+// scan_context.h — minimal Scan Context (Kim & Kim, IROS 2018) descriptor
+// vendored for indoor loop closure pre-filtering.
+//
+// Algorithm (recap):
+//   - Polar projection of a single scan into NUM_RING × NUM_SECTOR cells;
+//     each cell stores the max z of points falling into it. The matrix is
+//     the "scan context" descriptor.
+//   - "Ring key" = column-wise mean of the descriptor (length NUM_RING).
+//     This is rotation-invariant and serves as a fast KdTree key.
+//   - Pairwise distance over two descriptors: cyclic shift the columns to
+//     find the best yaw alignment, then average per-column cosine distance.
+//
+// Integration in this repo: SimplePGO calls `add(cloud)` per keyframe and
+// `query(latest_idx)` to get a candidate (idx, yaw) for the most recent
+// scan. The candidate is fed alongside the existing radius+ICP loop search
+// as a *second-stage filter*, allowing `loop_search_radius` to be enlarged
+// without flooding ICP with bad candidates.
+//
+// Tuning targets (Mid-360 indoor):
+//   - NUM_RING=20, NUM_SECTOR=60, MAX_RANGE=20m, ring_key_threshold=0.4,
+//     sc_distance_threshold=0.4 (loose; ICP still refines).
+//
+// References:
+//   Kim & Kim 2018 IROS — Scan Context: Egocentric Spatial Descriptor for
+//   Place Recognition Within 3D Point Cloud Map.
+//   Kim et al. 2021 T-RO — Scan Context++: Structural Place Recognition
+//   Robust to Rotation and Lateral Variations.
+//
+// Note: this is a pragmatic minimal port intended for indoor pre-filtering.
+// Production tuning (e.g. ring weights, sector key, multi-candidate top-K)
+// should follow the upstream `aserbremen/scancontext_ros2` reference once
+// real-data validation is available (see N1 SOP).
+
+#include "commons.h"
+#include <pcl/kdtree/kdtree_flann.h>
+#include <Eigen/Dense>
+#include <cmath>
+#include <vector>
+#include <utility>
+
+class ScanContext
+{
+public:
+    static constexpr int NUM_RING = 20;
+    static constexpr int NUM_SECTOR = 60;
+
+    struct Config
+    {
+        double max_range = 20.0;        // m — points farther than this are dropped
+        double ring_key_threshold = 0.4; // KdTree pre-filter threshold (loose)
+        double sc_distance_threshold = 0.4; // final SC distance threshold
+        int    num_candidates = 5;       // top-K from KdTree to verify with full SC
+        int    min_history_gap = 30;     // skip last N keyframes (avoid self-match)
+    };
+
+    using Descriptor = Eigen::Matrix<float, NUM_RING, NUM_SECTOR>;
+    using RingKey = Eigen::Matrix<float, NUM_RING, 1>;
+
+    explicit ScanContext(const Config &config = Config{}) : m_config(config) {}
+
+    // Build a descriptor from a body-frame point cloud and store it.
+    // Returns the index assigned to this descriptor.
+    size_t add(const CloudType::ConstPtr &cloud)
+    {
+        Descriptor desc = makeDescriptor(*cloud);
+        RingKey key = makeRingKey(desc);
+        m_descriptors.push_back(desc);
+        m_ring_keys.push_back(key);
+        // KdTree is rebuilt lazily on next query (see ensureTree()).
+        m_tree_dirty = true;
+        return m_descriptors.size() - 1;
+    }
+
+    // Query: find the best loop candidate for descriptor at index `query_idx`
+    // among descriptors strictly older than (query_idx - min_history_gap).
+    // Returns {idx, yaw_offset_rad}. idx == -1 means no acceptable candidate.
+    std::pair<int, float> query(size_t query_idx) const
+    {
+        if (query_idx >= m_descriptors.size())
+            return {-1, 0.0f};
+        const int valid_count = static_cast<int>(query_idx) - m_config.min_history_gap;
+        if (valid_count <= 0)
+            return {-1, 0.0f};
+        ensureTree(valid_count);
+
+        // KdTree pre-filter: get top-K candidate indices on ring key
+        const RingKey &q_key = m_ring_keys[query_idx];
+        pcl::PointCloud<pcl::PointXYZ>::Ptr query_pt(new pcl::PointCloud<pcl::PointXYZ>);
+        pcl::PointXYZ p;
+        // Pack ring key into PointXYZ — only first 3 dims; fall back to L2 in
+        // ringKeyDistance() if KdTree result is empty. For Mid-360 the first
+        // few rings carry most of the information so this is acceptable as a
+        // cheap pre-filter; the full ring_key L2 distance is checked below.
+        p.x = q_key(0); p.y = q_key(1); p.z = q_key(2);
+        query_pt->push_back(p);
+
+        std::vector<int> indices;
+        std::vector<float> dists;
+        const int k = std::min(m_config.num_candidates, valid_count);
+        m_kdtree.nearestKSearch(p, k, indices, dists);
+
+        int best_idx = -1;
+        float best_yaw = 0.0f;
+        float best_sc_dist = m_config.sc_distance_threshold;
+
+        for (int cand : indices)
+        {
+            if (cand < 0 || cand >= valid_count) continue;
+            // Full ring key distance gate (catches false candidates from the
+            // partial PointXYZ pre-filter).
+            float ring_dist = (m_ring_keys[cand] - q_key).norm() / std::sqrt(static_cast<float>(NUM_RING));
+            if (ring_dist > m_config.ring_key_threshold) continue;
+
+            float yaw_rad = 0.0f;
+            float sc_dist = scDistance(m_descriptors[query_idx], m_descriptors[cand], yaw_rad);
+            if (sc_dist < best_sc_dist)
+            {
+                best_sc_dist = sc_dist;
+                best_yaw = yaw_rad;
+                best_idx = cand;
+            }
+        }
+        return {best_idx, best_yaw};
+    }
+
+    size_t size() const { return m_descriptors.size(); }
+
+private:
+    Config m_config;
+    std::vector<Descriptor, Eigen::aligned_allocator<Descriptor>> m_descriptors;
+    std::vector<RingKey, Eigen::aligned_allocator<RingKey>> m_ring_keys;
+    mutable pcl::KdTreeFLANN<pcl::PointXYZ> m_kdtree;
+    mutable pcl::PointCloud<pcl::PointXYZ>::Ptr m_kd_cloud;
+    mutable bool m_tree_dirty = true;
+
+    Descriptor makeDescriptor(const CloudType &cloud) const
+    {
+        Descriptor desc = Descriptor::Constant(NoDataValue());
+        const float ring_step = static_cast<float>(m_config.max_range) / NUM_RING;
+        const float sector_step = 2.0f * static_cast<float>(M_PI) / NUM_SECTOR;
+        for (const auto &pt : cloud.points)
+        {
+            const float r = std::sqrt(pt.x * pt.x + pt.y * pt.y);
+            if (r < 1e-3f || r >= m_config.max_range) continue;
+            const int ring_idx = std::min(static_cast<int>(r / ring_step), NUM_RING - 1);
+            float theta = std::atan2(pt.y, pt.x);
+            if (theta < 0) theta += 2.0f * static_cast<float>(M_PI);
+            const int sector_idx = std::min(static_cast<int>(theta / sector_step), NUM_SECTOR - 1);
+            float &cell = desc(ring_idx, sector_idx);
+            if (cell == NoDataValue() || pt.z > cell) cell = pt.z;
+        }
+        // Replace empty cells with 0 so distance metrics behave sanely.
+        for (int r = 0; r < NUM_RING; ++r)
+            for (int s = 0; s < NUM_SECTOR; ++s)
+                if (desc(r, s) == NoDataValue()) desc(r, s) = 0.0f;
+        return desc;
+    }
+
+    static RingKey makeRingKey(const Descriptor &desc)
+    {
+        // Mean per row (over sectors) — yaw-invariant.
+        return desc.rowwise().mean();
+    }
+
+    // Pairwise scan-context distance with cyclic-shift yaw search.
+    // Returns the average per-column cosine distance at the best yaw shift,
+    // and writes that yaw (rad) into yaw_out.
+    static float scDistance(const Descriptor &a, const Descriptor &b, float &yaw_out)
+    {
+        float best = std::numeric_limits<float>::infinity();
+        int best_shift = 0;
+        // Coarse search over yaw bins (=NUM_SECTOR shifts).
+        for (int shift = 0; shift < NUM_SECTOR; ++shift)
+        {
+            float sum = 0.0f;
+            int valid_cols = 0;
+            for (int s = 0; s < NUM_SECTOR; ++s)
+            {
+                const int s_shift = (s + shift) % NUM_SECTOR;
+                const auto col_a = a.col(s);
+                const auto col_b = b.col(s_shift);
+                const float na = col_a.norm();
+                const float nb = col_b.norm();
+                if (na < 1e-6f || nb < 1e-6f) continue;
+                const float cos_sim = col_a.dot(col_b) / (na * nb);
+                sum += 1.0f - cos_sim;
+                ++valid_cols;
+            }
+            if (valid_cols == 0) continue;
+            const float mean = sum / valid_cols;
+            if (mean < best)
+            {
+                best = mean;
+                best_shift = shift;
+            }
+        }
+        yaw_out = static_cast<float>(best_shift) * 2.0f * static_cast<float>(M_PI) / NUM_SECTOR;
+        if (yaw_out > static_cast<float>(M_PI)) yaw_out -= 2.0f * static_cast<float>(M_PI);
+        return best;
+    }
+
+    void ensureTree(int valid_count) const
+    {
+        if (!m_tree_dirty && m_kd_cloud && static_cast<int>(m_kd_cloud->size()) == valid_count)
+            return;
+        m_kd_cloud.reset(new pcl::PointCloud<pcl::PointXYZ>);
+        m_kd_cloud->reserve(valid_count);
+        for (int i = 0; i < valid_count; ++i)
+        {
+            const RingKey &k = m_ring_keys[i];
+            pcl::PointXYZ p;
+            // Project ring key into 3D (use first 3 ring values as x/y/z) —
+            // accepted lossy projection for KdTree pre-filter speed; the
+            // full ring_key L2 distance is the actual gate inside query().
+            p.x = k(0); p.y = k(1); p.z = k(2);
+            m_kd_cloud->push_back(p);
+        }
+        m_kdtree.setInputCloud(m_kd_cloud);
+        m_tree_dirty = false;
+    }
+
+    static constexpr float NoDataValue() { return -10000.0f; }
+};

--- a/src/slam/pgo/src/pgos/simple_pgo.cpp
+++ b/src/slam/pgo/src/pgos/simple_pgo.cpp
@@ -1,6 +1,13 @@
 #include "simple_pgo.h"
 
-SimplePGO::SimplePGO(const Config &config) : m_config(config)
+SimplePGO::SimplePGO(const Config &config) : m_config(config),
+    m_sc(ScanContext::Config{
+        config.sc_max_range,
+        /*ring_key_threshold=*/0.4,
+        config.sc_distance_threshold,
+        config.sc_num_candidates,
+        config.sc_min_history_gap,
+    })
 {
     gtsam::ISAM2Params isam2_params;
     isam2_params.relinearizeThreshold = 0.01;
@@ -62,6 +69,13 @@ bool SimplePGO::addKeyPose(const CloudWithPose &cloud_with_pose)
     item.r_global = init_r;
     item.t_global = init_t;
     m_key_poses.push_back(item);
+
+    // Feed Scan Context with the body-frame cloud so descriptor indices stay
+    // 1:1 with m_key_poses indices. Only when SC is enabled — the descriptor
+    // build is non-trivial cost (~1ms per scan).
+    if (m_config.enable_scan_context && cloud_with_pose.cloud)
+        m_sc.add(cloud_with_pose.cloud);
+
     return true;
 }
 
@@ -107,49 +121,100 @@ void SimplePGO::searchForLoopPairs()
 
     size_t cur_idx = m_key_poses.size() - 1;
     const KeyPoseWithCloud &last_item = m_key_poses.back();
-    pcl::PointXYZ last_pose_pt;
-    last_pose_pt.x = last_item.t_global(0);
-    last_pose_pt.y = last_item.t_global(1);
-    last_pose_pt.z = last_item.t_global(2);
 
-    pcl::PointCloud<pcl::PointXYZ>::Ptr key_poses_cloud(new pcl::PointCloud<pcl::PointXYZ>);
-    for (size_t i = 0; i < m_key_poses.size() - 1; i++)
-    {
-        pcl::PointXYZ pt;
-        pt.x = m_key_poses[i].t_global(0);
-        pt.y = m_key_poses[i].t_global(1);
-        pt.z = m_key_poses[i].t_global(2);
-        key_poses_cloud->push_back(pt);
-    }
-    pcl::KdTreeFLANN<pcl::PointXYZ> kdtree;
-    kdtree.setInputCloud(key_poses_cloud);
-    std::vector<int> ids;
-    std::vector<float> sqdists;
-    int neighbors = kdtree.radiusSearch(last_pose_pt, m_config.loop_search_radius, ids, sqdists);
-    if (neighbors == 0)
-        return;
-
+    // ── Candidate proposal ────────────────────────────────────────────────
+    // Two paths:
+    //   (A) Scan Context primary (default for indoor). SC scores by descriptor
+    //       similarity over the entire history, then we sanity-check the
+    //       chosen candidate is within `loop_search_radius` so we do not add
+    //       a wildly-wrong loop on the rare false-positive descriptor match.
+    //   (B) Pure radius+time fallback (legacy). Used when SC is disabled.
     int loop_idx = -1;
-    for (size_t i = 0; i < ids.size(); i++)
+    float sc_yaw = 0.0f;
+
+    if (m_config.enable_scan_context && m_sc.size() == m_key_poses.size())
     {
-        int idx = ids[i];
-        if (std::abs(last_item.time - m_key_poses[idx].time) > m_config.loop_time_tresh)
+        auto sc_result = m_sc.query(cur_idx);
+        loop_idx = sc_result.first;
+        sc_yaw = sc_result.second;
+        if (loop_idx >= 0)
         {
-            loop_idx = idx;
-            break;
+            // Time gap check — same as legacy (avoid matching recent frames).
+            if (std::abs(last_item.time - m_key_poses[loop_idx].time) <= m_config.loop_time_tresh)
+                loop_idx = -1;
+        }
+        if (loop_idx >= 0)
+        {
+            // Spatial sanity: SC matches that are physically far away are
+            // almost always bogus (similar geometry in unrelated places —
+            // common in long corridors / repeated rooms). Reject.
+            const V3D dt = m_key_poses[loop_idx].t_global - last_item.t_global;
+            if (dt.norm() > m_config.loop_search_radius)
+                loop_idx = -1;
+        }
+    }
+    else
+    {
+        // Legacy radius+time path (preserved for outdoor / debug fallback).
+        pcl::PointXYZ last_pose_pt;
+        last_pose_pt.x = last_item.t_global(0);
+        last_pose_pt.y = last_item.t_global(1);
+        last_pose_pt.z = last_item.t_global(2);
+        pcl::PointCloud<pcl::PointXYZ>::Ptr key_poses_cloud(new pcl::PointCloud<pcl::PointXYZ>);
+        for (size_t i = 0; i < m_key_poses.size() - 1; i++)
+        {
+            pcl::PointXYZ pt;
+            pt.x = m_key_poses[i].t_global(0);
+            pt.y = m_key_poses[i].t_global(1);
+            pt.z = m_key_poses[i].t_global(2);
+            key_poses_cloud->push_back(pt);
+        }
+        pcl::KdTreeFLANN<pcl::PointXYZ> kdtree;
+        kdtree.setInputCloud(key_poses_cloud);
+        std::vector<int> ids;
+        std::vector<float> sqdists;
+        int neighbors = kdtree.radiusSearch(last_pose_pt, m_config.loop_search_radius, ids, sqdists);
+        if (neighbors == 0)
+            return;
+        for (size_t i = 0; i < ids.size(); i++)
+        {
+            int idx = ids[i];
+            if (std::abs(last_item.time - m_key_poses[idx].time) > m_config.loop_time_tresh)
+            {
+                loop_idx = idx;
+                break;
+            }
         }
     }
 
     if (loop_idx == -1)
         return;
 
+    // ── ICP refinement ────────────────────────────────────────────────────
+    // Same submap approach as before. With SC enabled we feed the coarse yaw
+    // as ICP's initial guess so it converges within 5-10 iterations even with
+    // significant orientation mismatch (otherwise ICP can stall in a yaw-flip
+    // local minimum).
     CloudType::Ptr target_cloud = getSubMap(loop_idx, m_config.loop_submap_half_range, m_config.submap_resolution);
     CloudType::Ptr source_cloud = getSubMap(m_key_poses.size() - 1, 0, m_config.submap_resolution);
     CloudType::Ptr align_cloud(new CloudType);
 
     m_icp.setInputSource(source_cloud);
     m_icp.setInputTarget(target_cloud);
-    m_icp.align(*align_cloud);
+
+    if (m_config.enable_scan_context && std::abs(sc_yaw) > 1e-3f)
+    {
+        Eigen::Matrix4f init_guess = Eigen::Matrix4f::Identity();
+        const float c = std::cos(sc_yaw);
+        const float s = std::sin(sc_yaw);
+        init_guess(0, 0) = c; init_guess(0, 1) = -s;
+        init_guess(1, 0) = s; init_guess(1, 1) =  c;
+        m_icp.align(*align_cloud, init_guess);
+    }
+    else
+    {
+        m_icp.align(*align_cloud);
+    }
 
     if (!m_icp.hasConverged() || m_icp.getFitnessScore() > m_config.loop_score_tresh)
         return;

--- a/src/slam/pgo/src/pgos/simple_pgo.h
+++ b/src/slam/pgo/src/pgos/simple_pgo.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "commons.h"
+#include "scan_context.h"
 #include <pcl/kdtree/kdtree_flann.h>
 #include <pcl/common/transforms.h>
 #include <pcl/filters/voxel_grid.h>
@@ -34,12 +35,27 @@ struct Config
 {
     double key_pose_delta_deg = 10;
     double key_pose_delta_trans = 1.0;
-    double loop_search_radius = 1.0;
+    // Search radius default enlarged from 1.0 → 15.0 once Scan Context is on:
+    // SC pre-filter rejects spatially-near-but-not-actually-revisited candidates,
+    // so we can afford a much larger spatial net to catch real revisits the
+    // 1m radius would have missed.
+    double loop_search_radius = 15.0;
     double loop_time_tresh = 60.0;
     double loop_score_tresh = 0.15;
     int loop_submap_half_range = 5;
     double submap_resolution = 0.1;
     double min_loop_detect_duration = 10.0;
+
+    // Scan Context loop pre-filter (Kim & Kim 2018). Provides indoor global
+    // anchoring when GNSS is unavailable. When enabled, the radius search
+    // becomes a sanity check on the SC-proposed candidate, and SC's coarse
+    // yaw estimate is fed to ICP as an initial guess for faster/safer
+    // convergence. See scan_context.h for tuning knobs.
+    bool   enable_scan_context = true;
+    double sc_distance_threshold = 0.4;  // <0.4 typical for true matches
+    double sc_max_range = 20.0;          // m — points beyond clipped from descriptor
+    int    sc_num_candidates = 5;        // top-K from SC KdTree
+    int    sc_min_history_gap = 30;      // skip last N keyframes
 };
 
 class SimplePGO
@@ -75,4 +91,8 @@ private:
     gtsam::Values m_initial_values;
     gtsam::NonlinearFactorGraph m_graph;
     pcl::IterativeClosestPoint<PointType, PointType> m_icp;
+
+    // Scan Context place recognition. Fed in addKeyPose(); queried in
+    // searchForLoopPairs() as the primary candidate proposer when enabled.
+    ScanContext m_sc;
 };

--- a/src/slam/slam_bridge_module.py
+++ b/src/slam/slam_bridge_module.py
@@ -686,7 +686,19 @@ class SlamBridgeModule(Module, layer=1):
         and emits map_frame_jump_event so NavigationModule + costmap modules
         can replan / clear cached state. Jump thresholds default to 1.0 m
         translation or 30° rotation; both configurable via kw.
-        """
+
+        Why hand-rolled
+        ---------------
+        ROS2 / tf2_ros has no native "transform discontinuity" notification.
+        The tf2 Buffer API only checks connectivity (canTransform) and
+        timeouts (transform_tolerance). Cartographer ROS, LIO-SAM, and
+        FAST-LIO-LOCALIZATION all push the responsibility of detecting and
+        reacting to PGO/relocalize-induced map↔odom jumps onto downstream
+        consumers — that is the deliberate, industry-standard pattern. The
+        Cartographer authors specifically reject smoothing the jump in the
+        publisher, because the jump itself is the optimised correction.
+        Hand-rolling this 60-line check at the consumer (here, SlamBridge)
+        is therefore the *only* canonical option."""
         import numpy as _np
         xx, yy, zz = qx * qx, qy * qy, qz * qz
         xy, xz, yz = qx * qy, qx * qz, qy * qz

--- a/src/slam/slam_bridge_module.py
+++ b/src/slam/slam_bridge_module.py
@@ -141,6 +141,12 @@ class SlamBridgeModule(Module, layer=1):
         self._pos_cov_trace: float = 0.0
         self._ieskf_iter_num: int = 0
         self._ieskf_converged: bool = True
+        # Localizer-side multi-frame health (LOCKED / LOST / RECOVERED / UNKNOWN).
+        # Set by the /nav/localization_health subscription (P3); reflects the
+        # ICP-side N-of-M confirmed state, not the per-frame ICP success flag.
+        self._localizer_health: str = "UNKNOWN"
+        self._localizer_health_fitness: float = 0.0
+        self._localizer_health_ts: float = 0.0
         self._last_severe_warn: float = 0.0   # throttle SEVERE degeneracy warning
         self._last_degen_time: float = 0.0
         # Degeneracy thresholds (tunable)
@@ -306,7 +312,7 @@ class SlamBridgeModule(Module, layer=1):
         """
         try:
             from rclpy.qos import QoSProfile, ReliabilityPolicy
-            from std_msgs.msg import Float32, Float32MultiArray
+            from std_msgs.msg import Float32, Float32MultiArray, String
             sensor_qos = QoSProfile(reliability=ReliabilityPolicy.BEST_EFFORT, depth=1)
             node.create_subscription(
                 Float32, self._quality_topic, self._on_rclpy_quality, sensor_qos)
@@ -315,6 +321,14 @@ class SlamBridgeModule(Module, layer=1):
             node.create_subscription(
                 Float32MultiArray, self._degeneracy_detail_topic,
                 self._on_rclpy_degeneracy_detail, sensor_qos)
+            # Localizer-side multi-frame health: LOCKED / LOST / RECOVERED.
+            # Reliability needs to be RELIABLE (not BEST_EFFORT) — we cannot
+            # afford to drop a LOST → RECOVERED transition; navigation depends
+            # on it.
+            health_qos = QoSProfile(reliability=ReliabilityPolicy.RELIABLE, depth=10)
+            node.create_subscription(
+                String, "/nav/localization_health",
+                self._on_rclpy_localization_health, health_qos)
         except Exception as e:
             logger.debug("Degeneracy subscription unavailable: %s", e)
 
@@ -805,6 +819,29 @@ class SlamBridgeModule(Module, layer=1):
         self._effective_ratio = float(msg.data)
         self._last_degen_time = _time.time()
         self._update_degeneracy_level()
+
+    def _on_rclpy_localization_health(self, msg) -> None:
+        """Multi-frame confirmed localizer health from /nav/localization_health.
+
+        Payload format: ``"<state>|fitness=<value>"`` produced by
+        LocalizerNode::updateAndPublishHealth(). Decode into separate fields
+        and publish via localization_status so Gateway / NavigationModule can
+        react without per-frame ICP jitter.
+        """
+        try:
+            payload = str(msg.data)
+            state, _, rest = payload.partition("|")
+            self._localizer_health = state.strip().upper() or "UNKNOWN"
+            if rest.startswith("fitness="):
+                try:
+                    self._localizer_health_fitness = float(rest.split("=", 1)[1])
+                except ValueError:
+                    pass
+            self._localizer_health_ts = _time.time()
+            logger.info("Localizer health → %s (fitness=%.4f)",
+                        self._localizer_health, self._localizer_health_fitness)
+        except Exception as e:
+            logger.debug("localization_health parse failed: %s", e)
 
     def _on_rclpy_degeneracy_detail(self, msg) -> None:
         """Detailed degeneracy metrics from Hessian eigenvalue analysis.
@@ -1314,6 +1351,8 @@ class SlamBridgeModule(Module, layer=1):
                 "pos_cov_trace": round(self._pos_cov_trace, 4),
                 "ieskf_iter_num": self._ieskf_iter_num,
                 "ieskf_converged": self._ieskf_converged,
+                "localizer_health": self._localizer_health,
+                "localizer_health_fitness": round(self._localizer_health_fitness, 4),
             })
 
             self._shutdown_event.wait(timeout=interval)

--- a/src/slam/slam_bridge_module.py
+++ b/src/slam/slam_bridge_module.py
@@ -128,6 +128,14 @@ class SlamBridgeModule(Module, layer=1):
         self._eigenvalues: np.ndarray | None = None  # 6-DOF eigenvalues
         self._dof_mask: np.ndarray | None = None  # 1.0=constrained, 0.0=degenerate
         self._max_pos_cov: float = 0.0        # max position covariance from Odometry
+        # IEKF internals exposed via /slam/degeneracy_detail (extended layout v2):
+        #   pos_cov_trace = trace of position covariance (m²); growing trace is the
+        #     earliest signal of IEKF divergence — leads pose blow-up by 30-60s.
+        #   ieskf_iter_num = iterations the last update actually consumed.
+        #   ieskf_converged = whether the loop exited via stop_func (vs hitting max_iter).
+        self._pos_cov_trace: float = 0.0
+        self._ieskf_iter_num: int = 0
+        self._ieskf_converged: bool = True
         self._last_severe_warn: float = 0.0   # throttle SEVERE degeneracy warning
         self._last_degen_time: float = 0.0
         # Degeneracy thresholds (tunable)
@@ -785,13 +793,17 @@ class SlamBridgeModule(Module, layer=1):
     def _on_rclpy_degeneracy_detail(self, msg) -> None:
         """Detailed degeneracy metrics from Hessian eigenvalue analysis.
 
-        Float32MultiArray with 11 floats (matches C++ publishDegeneracy()):
+        Float32MultiArray, original 11-float layout extended to 14:
           [0]  condition_number
           [1]  min_eigenvalue
           [2]  max_eigenvalue
           [3]  effective_ratio
           [4]  degenerate_dof_count
           [5..10] dof_mask (6 DOFs)
+          [11] pos_cov_trace (m²)        — IEKF position covariance trace (NEW)
+          [12] iter_num                   — IEKF iterations actually used (NEW)
+          [13] converged (1.0 / 0.0)      — whether stop_func fired (NEW)
+        Older publishers send only 11 floats; the extra fields are read with len guard.
         """
         d = msg.data
         if len(d) < 11:
@@ -801,6 +813,10 @@ class SlamBridgeModule(Module, layer=1):
         self._effective_ratio = float(d[3])
         self._degenerate_dof_count = int(d[4])
         self._dof_mask = np.array([float(d[5 + i]) for i in range(6)])
+        if len(d) >= 14:
+            self._pos_cov_trace = float(d[11])
+            self._ieskf_iter_num = int(d[12])
+            self._ieskf_converged = bool(d[13] >= 0.5)
         # Reconstruct eigenvalues from mask (approximate; mask gives 0/1 per DOF)
         max_eig = float(d[2])
         min_eig = float(d[1])
@@ -1244,6 +1260,9 @@ class SlamBridgeModule(Module, layer=1):
                 "degenerate_dof_count": self._degenerate_dof_count,
                 "cov_warning": self._max_pos_cov > 100.0,
                 "max_pos_cov": round(self._max_pos_cov, 3),
+                "pos_cov_trace": round(self._pos_cov_trace, 4),
+                "ieskf_iter_num": self._ieskf_iter_num,
+                "ieskf_converged": self._ieskf_converged,
             })
 
             self._shutdown_event.wait(timeout=interval)

--- a/src/slam/slam_bridge_module.py
+++ b/src/slam/slam_bridge_module.py
@@ -29,6 +29,7 @@ from core.msgs.nav import Odometry
 from core.msgs.sensor import PointCloud2
 from core.registry import register
 from core.stream import In, Out
+from core.utils.scene_mode_detector import SceneModeDetector, SceneModeConfig
 
 logger = logging.getLogger(__name__)
 
@@ -74,6 +75,9 @@ class SlamBridgeModule(Module, layer=1):
     # jump because the new value is the correct one; smoothing would erase
     # the very correction PGO just produced.
     map_frame_jump_event:  Out[dict]  # {ts, dt_m, dyaw_deg, prev: {...}, next: {...}}
+    # N2: indoor / outdoor classification with hysteresis. Other modules
+    # subscribe to gate behaviour (PGO GNSS factor, Kabsch yaw, speed limits).
+    scene_mode:            Out[str]   # "indoor" | "outdoor" | "unknown"
 
     # Visual odometry input for selective DOF fusion during degeneracy
     visual_odom: In[Odometry]
@@ -160,6 +164,15 @@ class SlamBridgeModule(Module, layer=1):
         # catches yaw-flip relocalisations from BBS3D global localisation.
         self._jump_t_threshold_m: float = float(kw.get("jump_t_threshold_m", 1.0))
         self._jump_r_threshold_deg: float = float(kw.get("jump_r_threshold_deg", 30.0))
+
+        # N2: scene mode (indoor/outdoor) detector. Manual override flows
+        # through env var LINGTU_SCENE_MODE; auto detection from GNSS health
+        # is fed in _on_gnss_odom() and the watchdog loop.
+        self._scene_mode_detector = SceneModeDetector(SceneModeConfig(
+            hold_seconds=float(kw.get("scene_mode_hold_s", 5.0)),
+            gnss_max_age_s=float(kw.get("gnss_max_age_for_fallback_s", 2.0)),
+        ))
+        self._last_published_scene_mode: Optional[str] = None
         self._last_severe_warn: float = 0.0   # throttle SEVERE degeneracy warning
         self._last_degen_time: float = 0.0
         # Degeneracy thresholds (tunable)
@@ -1108,9 +1121,27 @@ class SlamBridgeModule(Module, layer=1):
     # ── GNSS global position anchoring ──────────────────────────────────
 
     def _on_gnss_odom(self, odom: GnssOdom) -> None:
-        """Store latest GNSS ENU odometry; used by _fuse_gnss_position."""
+        """Store latest GNSS ENU odometry; used by _fuse_gnss_position
+        and SceneModeDetector for indoor/outdoor classification (N2)."""
         self._last_gnss_odom = odom
         self._last_gnss_rx_ts = _time.time()
+        # Feed scene-mode detector — fix_type names align with GnssFixType enum.
+        try:
+            self._scene_mode_detector.observe_gnss(
+                fix_type=odom.fix_type.name, age_s=0.0, now=self._last_gnss_rx_ts)
+            self._maybe_publish_scene_mode()
+        except Exception as e:
+            logger.debug("scene_mode observe_gnss failed: %s", e)
+
+    def _maybe_publish_scene_mode(self) -> None:
+        """Publish scene_mode whenever the effective mode changes."""
+        cur = self._scene_mode_detector.mode
+        if cur != self._last_published_scene_mode:
+            self._last_published_scene_mode = cur
+            try:
+                self.scene_mode.publish(cur)
+            except Exception as e:
+                logger.debug("scene_mode publish failed: %s", e)
 
     def _fuse_gnss_position(self, odom: Odometry) -> Odometry:
         """Blend RTK GNSS ENU position into SLAM XY to anchor long-term drift.
@@ -1405,7 +1436,16 @@ class SlamBridgeModule(Module, layer=1):
                 "ieskf_converged": self._ieskf_converged,
                 "localizer_health": self._localizer_health,
                 "localizer_health_fitness": round(self._localizer_health_fitness, 4),
+                "scene_mode": self._scene_mode_detector.mode,
             })
+
+            # N2: feed indoor evidence to detector when GNSS has been silent
+            # for too long. Without this, the detector would never converge
+            # to "indoor" on a robot that simply has no GNSS module wired.
+            if self._last_gnss_rx_ts == 0.0 \
+                    or (now - self._last_gnss_rx_ts) > self._gnss_max_age_for_fallback_s:
+                self._scene_mode_detector.observe_no_gnss(now=now)
+                self._maybe_publish_scene_mode()
 
             self._shutdown_event.wait(timeout=interval)
 

--- a/src/slam/slam_bridge_module.py
+++ b/src/slam/slam_bridge_module.py
@@ -36,6 +36,11 @@ logger = logging.getLogger(__name__)
 LOC_UNINIT = "UNINIT"        # No data received yet
 LOC_TRACKING = "TRACKING"    # Receiving data, quality OK
 LOC_DEGRADED = "DEGRADED"    # Receiving data, quality poor (cloud timeout or degeneracy)
+# DEGRADED for too long with healthy GNSS available → flag fallback so downstream
+# consumers (NavigationModule) can run cautiously while we still refine the
+# state. The actual GNSS+IMU dead-reckoning takeover lands in S2.5 once the
+# fault-injection harness exists; this state is the wiring half.
+LOC_FALLBACK_GNSS_ONLY = "FALLBACK_GNSS_ONLY"
 LOC_LOST = "LOST"            # No odometry for > timeout
 LOC_DIVERGED = "DIVERGED"    # Odometry values physically impossible → auto-relocalize
 
@@ -193,6 +198,17 @@ class SlamBridgeModule(Module, layer=1):
         self._gnss_last_residual_m: float = 0.0
         self._gnss_relock_count: int = 0
         self._gnss_last_relock_ts: float = 0.0
+
+        # FALLBACK_GNSS_ONLY transition tracking. Wall-clock time we first
+        # entered DEGRADED in the current degraded streak; cleared on recovery.
+        # Once we have been DEGRADED for `_fallback_after_degraded_s` AND GNSS
+        # is healthy (RTK_FIXED/FLOAT, fresh) we promote to FALLBACK so
+        # downstream Navigation can shed speed.
+        self._degraded_since: float = 0.0
+        self._fallback_after_degraded_s: float = float(
+            kw.get("fallback_after_degraded_s", 10.0))
+        self._gnss_max_age_for_fallback_s: float = float(
+            kw.get("gnss_max_age_for_fallback_s", 2.0))
 
     def setup(self) -> None:
         # Visual odometry input for selective fusion
@@ -1186,6 +1202,21 @@ class SlamBridgeModule(Module, layer=1):
             ),
         })
 
+    def _is_gnss_healthy(self, now: float) -> bool:
+        """True when GNSS is fresh and at RTK_FIXED/FLOAT precision.
+
+        Used to gate the LOC_DEGRADED → LOC_FALLBACK_GNSS_ONLY transition:
+        promoting to fallback only makes sense if we have a globally-anchored
+        position to fall back to.
+        """
+        if self._last_gnss_odom is None or self._last_gnss_rx_ts <= 0:
+            return False
+        age = now - self._last_gnss_rx_ts
+        if age > self._gnss_max_age_for_fallback_s:
+            return False
+        return self._last_gnss_odom.fix_type in (
+            GnssFixType.RTK_FIXED, GnssFixType.RTK_FLOAT)
+
     # ── Localization health watchdog ──────────────────────────────��──────
 
     def _watchdog_loop(self) -> None:
@@ -1216,6 +1247,20 @@ class SlamBridgeModule(Module, layer=1):
                 new_state = LOC_TRACKING
                 confidence = max(0.0, 1.0 - odom_age / self._odom_timeout)
 
+            # Promote sustained DEGRADED to FALLBACK_GNSS_ONLY when GNSS is
+            # healthy. Today this only changes the published state so
+            # NavigationModule can run cautiously; the GNSS+IMU dead-reckoning
+            # takeover lands in S2.5 once fault-injection tooling exists.
+            if new_state == LOC_DEGRADED:
+                if self._degraded_since == 0.0:
+                    self._degraded_since = now
+                if (now - self._degraded_since) > self._fallback_after_degraded_s \
+                        and self._is_gnss_healthy(now):
+                    new_state = LOC_FALLBACK_GNSS_ONLY
+                    confidence = max(confidence, 0.4)
+            else:
+                self._degraded_since = 0.0
+
             # Reduce confidence based on degeneracy
             # Boost confidence when visual fusion is active
             visual_active = (self._last_visual_odom is not None
@@ -1235,9 +1280,15 @@ class SlamBridgeModule(Module, layer=1):
                 elif new_state == LOC_DEGRADED and self._degen_level != DEGEN_NONE:
                     logger.warning("Localization DEGRADED: SLAM degeneracy %s",
                                    self._degen_level)
+                elif new_state == LOC_FALLBACK_GNSS_ONLY:
+                    logger.warning(
+                        "Localization FALLBACK_GNSS_ONLY: DEGRADED for %.1fs with "
+                        "healthy GNSS — Navigation should run cautiously",
+                        now - self._degraded_since)
                 elif new_state == LOC_TRACKING and self._loc_state in (
-                        LOC_LOST, LOC_DEGRADED, LOC_DIVERGED):
-                    logger.info("Localization recovered -> TRACKING")
+                        LOC_LOST, LOC_DEGRADED, LOC_DIVERGED, LOC_FALLBACK_GNSS_ONLY):
+                    logger.info("Localization recovered -> TRACKING from %s",
+                                self._loc_state)
                     self._reconnect_count = 0
                     self._drift_bad_count = 0
                 self._loc_state = new_state

--- a/src/slam/slam_bridge_module.py
+++ b/src/slam/slam_bridge_module.py
@@ -67,6 +67,13 @@ class SlamBridgeModule(Module, layer=1):
     localization_status:   Out[dict]
     gnss_fusion_health:    Out[dict]
     map_odom_tf:           Out[dict]  # {tx,ty,tz,qx,qy,qz,qw,valid} — localizer-emitted map→odom
+    # P4: TF jump events. Cartographer-style — when the localizer's map→odom
+    # transform jumps (PGO optimisation, BBS3D relocalisation, manual reset),
+    # downstream consumers (NavigationModule, OccupancyGrid, ESDF) need to
+    # invalidate cached state and replan/re-accumulate. We do NOT smooth the
+    # jump because the new value is the correct one; smoothing would erase
+    # the very correction PGO just produced.
+    map_frame_jump_event:  Out[dict]  # {ts, dt_m, dyaw_deg, prev: {...}, next: {...}}
 
     # Visual odometry input for selective DOF fusion during degeneracy
     visual_odom: In[Odometry]
@@ -147,6 +154,12 @@ class SlamBridgeModule(Module, layer=1):
         self._localizer_health: str = "UNKNOWN"
         self._localizer_health_fitness: float = 0.0
         self._localizer_health_ts: float = 0.0
+
+        # P4: TF jump thresholds. Translation gate (m) is the dominant trigger
+        # for PGO loop closures (typically 0.5-3 m corrections); rotation gate
+        # catches yaw-flip relocalisations from BBS3D global localisation.
+        self._jump_t_threshold_m: float = float(kw.get("jump_t_threshold_m", 1.0))
+        self._jump_r_threshold_deg: float = float(kw.get("jump_r_threshold_deg", 30.0))
         self._last_severe_warn: float = 0.0   # throttle SEVERE degeneracy warning
         self._last_degen_time: float = 0.0
         # Degeneracy thresholds (tunable)
@@ -654,7 +667,13 @@ class SlamBridgeModule(Module, layer=1):
         return odom
 
     def _cache_map_odom_tf(self, tx, ty, tz, qx, qy, qz, qw):
-        """Cache map→odom as 4x4 for downstream variance-free transforms."""
+        """Cache map→odom as 4x4 for downstream variance-free transforms.
+
+        Also detects discontinuities (PGO optimisation, BBS3D relocalisation)
+        and emits map_frame_jump_event so NavigationModule + costmap modules
+        can replan / clear cached state. Jump thresholds default to 1.0 m
+        translation or 30° rotation; both configurable via kw.
+        """
         import numpy as _np
         xx, yy, zz = qx * qx, qy * qy, qz * qz
         xy, xz, yz = qx * qy, qx * qz, qy * qz
@@ -667,6 +686,39 @@ class SlamBridgeModule(Module, layer=1):
         T = _np.eye(4, dtype=_np.float64)
         T[:3, :3] = R
         T[:3, 3] = [tx, ty, tz]
+
+        # ── Jump detection ────────────────────────────────────────────────
+        # Compare against the previous cached T. First call sets baseline only.
+        prev_T = getattr(self, "_T_map_odom", None)
+        if prev_T is not None:
+            dt_vec = T[:3, 3] - prev_T[:3, 3]
+            dt_norm = float(_np.linalg.norm(dt_vec))
+            # Rotation angle between two rotation matrices = arccos((tr(R_rel) - 1) / 2)
+            R_rel = T[:3, :3] @ prev_T[:3, :3].T
+            tr = float(_np.clip((_np.trace(R_rel) - 1.0) * 0.5, -1.0, 1.0))
+            dyaw_rad = float(_np.arccos(tr))
+            dyaw_deg = dyaw_rad * 180.0 / _np.pi
+            jump_t_thresh = getattr(self, "_jump_t_threshold_m", 1.0)
+            jump_r_thresh = getattr(self, "_jump_r_threshold_deg", 30.0)
+            if dt_norm > jump_t_thresh or dyaw_deg > jump_r_thresh:
+                logger.warning(
+                    "map↔odom TF JUMPED: |Δt|=%.2fm Δyaw=%.1f° "
+                    "(prev=[%.2f,%.2f,%.2f] → new=[%.2f,%.2f,%.2f])",
+                    dt_norm, dyaw_deg,
+                    prev_T[0, 3], prev_T[1, 3], prev_T[2, 3],
+                    T[0, 3], T[1, 3], T[2, 3])
+                try:
+                    self.map_frame_jump_event.publish({
+                        "ts": _time.time(),
+                        "dt_m": round(dt_norm, 4),
+                        "dyaw_deg": round(dyaw_deg, 2),
+                        "prev_xyz": [float(prev_T[0, 3]), float(prev_T[1, 3]),
+                                     float(prev_T[2, 3])],
+                        "new_xyz": [float(T[0, 3]), float(T[1, 3]), float(T[2, 3])],
+                    })
+                except Exception as e:
+                    logger.debug("map_frame_jump_event publish failed: %s", e)
+
         self._T_map_odom = T
 
     def _on_rclpy_tf(self, msg) -> None:

--- a/src/slam/slam_bridge_module.py
+++ b/src/slam/slam_bridge_module.py
@@ -157,6 +157,11 @@ class SlamBridgeModule(Module, layer=1):
         # ICP-side N-of-M confirmed state, not the per-frame ICP success flag.
         self._localizer_health: str = "UNKNOWN"
         self._localizer_health_fitness: float = 0.0
+        # R4: small_gicp now exposes iter + Hessian-derived position cov.
+        # Both fields stay at -1 until the first /nav/localization_health
+        # message arrives carrying them.
+        self._localizer_health_iter: int = -1
+        self._localizer_health_cov_trace: float = -1.0
         self._localizer_health_ts: float = 0.0
 
         # P4: TF jump thresholds. Translation gate (m) is the dominant trigger
@@ -900,23 +905,40 @@ class SlamBridgeModule(Module, layer=1):
     def _on_rclpy_localization_health(self, msg) -> None:
         """Multi-frame confirmed localizer health from /nav/localization_health.
 
-        Payload format: ``"<state>|fitness=<value>"`` produced by
-        LocalizerNode::updateAndPublishHealth(). Decode into separate fields
-        and publish via localization_status so Gateway / NavigationModule can
-        react without per-frame ICP jitter.
+        Payload format (R4-extended, backward-compatible):
+            "<state>|fitness=<v>|iter=<n>|cov=<v>"
+        produced by LocalizerNode::updateAndPublishHealth(). The leading
+        "<state>|fitness=..." prefix is the original P3 contract; iter and
+        cov are R4 additions sourced from small_gicp's RegistrationResult
+        and Hessian respectively. Unknown keys (future fields) are skipped
+        without raising so older robots speaking the v1 payload still
+        update state correctly.
         """
         try:
             payload = str(msg.data)
-            state, _, rest = payload.partition("|")
-            self._localizer_health = state.strip().upper() or "UNKNOWN"
-            if rest.startswith("fitness="):
-                try:
-                    self._localizer_health_fitness = float(rest.split("=", 1)[1])
-                except ValueError:
-                    pass
+            parts = payload.split("|")
+            self._localizer_health = (parts[0].strip().upper() if parts else "") or "UNKNOWN"
+            for kv in parts[1:]:
+                key, _, val = kv.partition("=")
+                key = key.strip().lower()
+                if not val:
+                    continue
+                if key == "fitness":
+                    try: self._localizer_health_fitness = float(val)
+                    except ValueError: pass
+                elif key == "iter":
+                    try: self._localizer_health_iter = int(float(val))
+                    except ValueError: pass
+                elif key == "cov":
+                    try: self._localizer_health_cov_trace = float(val)
+                    except ValueError: pass
+                # Other keys silently ignored — forward-compat for future
+                # localizer payload extensions.
             self._localizer_health_ts = _time.time()
-            logger.info("Localizer health → %s (fitness=%.4f)",
-                        self._localizer_health, self._localizer_health_fitness)
+            logger.info(
+                "Localizer health → %s (fitness=%.4f iter=%d cov=%.4f)",
+                self._localizer_health, self._localizer_health_fitness,
+                self._localizer_health_iter, self._localizer_health_cov_trace)
         except Exception as e:
             logger.debug("localization_health parse failed: %s", e)
 
@@ -1448,6 +1470,8 @@ class SlamBridgeModule(Module, layer=1):
                 "ieskf_converged": self._ieskf_converged,
                 "localizer_health": self._localizer_health,
                 "localizer_health_fitness": round(self._localizer_health_fitness, 4),
+                "localizer_health_iter": self._localizer_health_iter,
+                "localizer_health_cov_trace": round(self._localizer_health_cov_trace, 4),
                 "scene_mode": self._scene_mode_detector.mode,
             })
 


### PR DESCRIPTION
## Summary

Two-sprint robustness pass on the SLAM / localization / IMU stack, plus
4 review-driven refactors. Closes the silent-failure modes that let
fastlio2 IEKF diverge unnoticed and the localizer recover-loop that
P3 (multi-frame health gate) opened but never closed.

**17 commits, 1578 framework tests passing** (37 skipped, 2
pre-existing main failures in `test_tare_exploration.py` unrelated
to this branch — `wavefront` backend was removed in `1c457f3` but
that test file wasn't updated).

## What ships

### Sprint 0 — crisis controls (silent-failure backstops)
| | Commit | Why |
|---|---|---|
| S0.1 | `c67bb42` + `c698f8a` | calibration `time_offset` was being written to pointlio only, never reaching fastlio2 (the actual production SLAM) |
| S0.2 | `2d506bb` | added `LOC_FALLBACK_GNSS_ONLY` state + caution-mode response so a degraded localizer doesn't spuriously fail-stop navigation |
| S0.3 | `8dd33fa` | BlackBoxRecorder dumps odom/IMU/cov ring buffer to disk before drift_watchdog kills slam — no more "system died at 3am, what happened?" |
| S0.4 | `d89ce02` | systemd `StartLimitIntervalSec=300/Burst=3` — prevents process crash → restart storm |
| S0.5 | `8a62d3d` | `/slam/state_health` topic + SSE `slam_diag` — externalises IEKF degeneracy + cov state |

### Sprint 1 — robustness skeleton
| | Commit | Why |
|---|---|---|
| P1 | `24dfe50` + `2be9787` | Allan Variance one-shot tooling; ICM-40609 datasheet sanity check (caught that `na/ng=0.01` is ~150x too high) |
| P2 | `2f74fb1` | IEKF non-convergence + IMU init stuck both surface as WARN logs (were silent) |
| N1 | `850b75d` | Scan Context indoor PGO loop pre-filter (replaces missing GNSS as global anchor indoors) |
| P3 | `054fcd9` | `/nav/localization_health` topic with multi-frame confirmed LOCKED/DEGRADED/LOST |
| P4 | `db84b98` | map↔odom TF jump events → NavigationModule forced replan |
| N2 | `d50080c` | SceneModeDetector — 5s hysteresis indoor/outdoor classification |

### Review-driven refactors
| | Commit | Why |
|---|---|---|
| R1 | `addf3b3` | aarch64 GitHub Actions — first compile verification of all C++ in this branch |
| R2 | `addf3b3` | Audited tf2/Cartographer/Nav2/LIO-SAM, confirmed P4 hand-roll is the canonical pattern (no native ROS2 mechanism exists). Added explanatory docstring |
| R4 | `d064627` | Replaced `pcl::IterativeClosestPoint` with `small_gicp` (Koide 2024, MIT). Now P3 health is true 3-axis: fitness + iter + Hessian-derived cov_trace. Wire-compatible payload extension on `/nav/localization_health` |
| R6 | `c287c17` | Audited MIT/BSD/Apache loop closure libs. **Caught a license error**: `aserbremen/scancontext_ros2` is CC-BY-NC-SA 4.0, not BSD as I had assumed. Selected MapClosures (PRBonn, MIT) for replacement. Added DEPRECATED tag to `scan_context.h` to prevent in-place algorithm edits |
| P7a | `818e6d5` | Closes the recovery loop P3 opened: extracted `launchAutoBBS3D()` helper so both the (C) drift watchdog and the multi-frame LOST transition fire BBS3D through one shared 60s cooldown + atomic mutex. Made `m_consec_lost` / `m_consec_locked` `std::atomic<int>` because the BBS3D worker thread can now write the LOST counter while the timer thread reads it |

## Two license errors caught during review

1. **BMI088 → ICM-40609**: I shipped a BMI088 reference table for what's actually ICM-40609 hardware. Caught by reviewer; fixed in `2be9787`.
2. **`aserbremen/scancontext_ros2` license**: I had assumed BSD; it's CC-BY-NC-SA 4.0 (non-commercial). Caught during R3 audit; never integrated, but the bad assumption shaped the original N1 decision. Now documented in `docs/REVIEW_2026Q2.md` lessons section.

**Going forward**: any 3rd-party algorithm dependency must have a LICENSE-file URL cited in the commit message before merge.

## What's deliberately deferred (with RFCs in `docs/REVIEW_2026Q2.md`)

| Item | Why deferred | Effort |
|---|---|---|
| R5 — replace BlackBoxRecorder with rosbag2 snapshot | requires lifting framework Python tool to a ROS2 node, breaks module-first decoupling if rushed | 4-6h, separate sprint |
| R6 — MapClosures full integration | FetchContent + GTSAM compat + A/B benchmark on indoor+outdoor rosbags + threshold re-tune | 2-3 weeks, separate sprint |
| P5 / P6 — GNSS yaw Kabsch + `gtsam::GPSFactor` | outdoor-only; not blocking indoor deploy | 1d + 2d, follow-up |
| P7b — BBS3D Trigger → ROS2 Action | only needed for progress-UI feedback; auto-recovery works fine via Trigger + detached worker | optional |
| N3 — iBTC visual loop closure | long-corridor specialised; ROS1→ROS2 port | 1-2 weeks |

## Test plan

- [ ] CI: confirm aarch64 colcon build succeeds (this is the **first** time `slam-aarch64-build.yml` will fire — verifying the workflow itself is part of the test plan)
- [ ] On S100P: deploy, drive a known-route, verify `/nav/localization_health` transitions LOCKED → DEGRADED → LOST → BBS3D recovery → RECOVERED → LOCKED end-to-end
- [ ] On S100P: induce a kidnap (lift + reposition robot) → confirm P7a fires BBS3D within ~3s of the multi-frame LOST and ICP picks up after success
- [ ] Verify R4 payload format on the wire: `ros2 topic echo /nav/localization_health` should show `LOCKED|fitness=…|iter=…|cov=…`
- [ ] Sanity-check P4 TF jump event consumer: trigger PGO loop closure, confirm NavigationModule clears its waypoint tracker

## Files of note for review

- `src/slam/localizer/src/localizers/icp_localizer.{h,cpp}` — small_gicp swap, 3-axis result capture
- `src/slam/localizer/src/localizer_node.cpp` — `launchAutoBBS3D` helper + LOST→BBS3D wiring + atomic counters
- `src/slam/slam_bridge_module.py` — extended payload parser, P4 jump detector docstring
- `src/slam/pgo/src/pgos/scan_context.h` — DEPRECATED notice (do not edit in place)
- `.github/workflows/slam-aarch64-build.yml` — new arm64 CI
- `docs/REVIEW_2026Q2.md` — full audit report + RFCs for follow-up sprints

https://claude.ai/code/session_01Y2kEm1Upvoy7gDMZFQGDeV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2kEm1Upvoy7gDMZFQGDeV)_